### PR TITLE
🛡️ Sentinel: Fix Terminal Injection in DataProcessor logs

### DIFF
--- a/ivi_water/data_processor.py
+++ b/ivi_water/data_processor.py
@@ -19,6 +19,7 @@ import numpy as np
 
 # Local imports
 from .export_utils import sanitize_dataframe, sanitize_filename
+from .security_utils import sanitize_for_terminal
 
 # Constants
 DEFAULT_DATA_DIR = "./data"
@@ -169,13 +170,16 @@ class DataProcessor:
             # Process results as they complete
             for future in as_completed(future_to_loc):
                 location_id = future_to_loc[future]
+                # Sanitize location ID for logging to prevent terminal injection
+                safe_loc_id = sanitize_for_terminal(location_id)
+
                 try:
                     water_data = future.result()
 
                     # Validate API response
                     if not water_data:
                         self.logger.warning(
-                            f"No data returned for location {location_id}"
+                            f"No data returned for location {safe_loc_id}"
                         )
                         continue
 
@@ -188,16 +192,16 @@ class DataProcessor:
                         all_rows.extend(rows)
                         successful_locations += 1
                         self.logger.debug(
-                            f"Successfully loaded {len(rows)} records for {location_id}"
+                            f"Successfully loaded {len(rows)} records for {safe_loc_id}"
                         )
                     else:
                         self.logger.warning(
-                            f"No valid rows created for location {location_id}"
+                            f"No valid rows created for location {safe_loc_id}"
                         )
 
                 except Exception as e:
                     self.logger.error(
-                        f"Failed to load water data for {location_id}: {e}",
+                        f"Failed to load water data for {safe_loc_id}: {e}",
                         exc_info=True,
                     )
                     continue
@@ -340,14 +344,16 @@ class DataProcessor:
         rows = self._convert_api_response_to_tuples(api_data, location_id)
 
         if not rows:
+            safe_loc_id = sanitize_for_terminal(location_id)
             self.logger.warning(
-                f"No valid data rows created for location {location_id}"
+                f"No valid data rows created for location {safe_loc_id}"
             )
             return pd.DataFrame()
 
         df = pd.DataFrame(rows, columns=WATER_DATA_COLUMNS)
+        safe_loc_id = sanitize_for_terminal(location_id)
         self.logger.debug(
-            f"Created DataFrame with {len(df)} rows for location {location_id}"
+            f"Created DataFrame with {len(df)} rows for location {safe_loc_id}"
         )
         return df
 
@@ -660,7 +666,8 @@ class DataProcessor:
         # Convert to Path object for consistent handling
         file_path = Path(file_path)
 
-        self.logger.info(f"Loading NRM impact data from: {file_path}")
+        safe_path = sanitize_for_terminal(str(file_path))
+        self.logger.info(f"Loading NRM impact data from: {safe_path}")
 
         try:
             # Load CSV with error handling using safe loader

--- a/tests/test_data_processor_security.py
+++ b/tests/test_data_processor_security.py
@@ -1,0 +1,98 @@
+
+import logging
+import unittest
+from unittest.mock import MagicMock
+from ivi_water.data_processor import DataProcessor
+from ivi_water.security_utils import sanitize_for_terminal
+
+# Malicious ID with ANSI escape sequence (Red color)
+MALICIOUS_ID = "V001\x1b[31m"
+SANITIZED_ID = sanitize_for_terminal(MALICIOUS_ID)
+
+class TestDataProcessorSecurity(unittest.TestCase):
+    def test_log_injection(self):
+        """
+        Verify that user inputs (location IDs) are sanitized before being logged to prevent Terminal Injection.
+        """
+        # Setup capturing logger
+        logger = logging.getLogger("ivi_water.data_processor")
+        logger.setLevel(logging.INFO)
+
+        from io import StringIO
+        capture = StringIO()
+        handler = logging.StreamHandler(capture)
+        logger.addHandler(handler)
+
+        try:
+            processor = DataProcessor()
+
+            # Mock API client to raise exception for the malicious ID
+            mock_client = MagicMock()
+            def side_effect(loc, *args):
+                if loc == MALICIOUS_ID:
+                    raise ValueError("Invalid ID")
+                return {}
+
+            mock_client.get_seasonal_water_data.side_effect = side_effect
+
+            # Call the method
+            try:
+                processor.load_water_data_from_api(
+                    mock_client, [MALICIOUS_ID], 2020, 2021
+                )
+            except ValueError:
+                # Expected failure because the only location failed
+                pass
+
+            # Check logs
+            log_output = capture.getvalue()
+
+            # The raw escape sequence should NOT be in the logs
+            self.assertNotIn("\x1b[", log_output, "ANSI escape sequence found in logs!")
+
+            # The sanitized ID SHOULD be in the logs
+            self.assertIn(SANITIZED_ID, log_output, "Sanitized ID not found in logs")
+
+        finally:
+            logger.removeHandler(handler)
+
+    def test_log_sanitization_success_path(self):
+        """
+        Verify that even successful operations log sanitized IDs.
+        """
+        # Setup capturing logger
+        logger = logging.getLogger("ivi_water.data_processor")
+        logger.setLevel(logging.DEBUG)  # Enable debug logs
+
+        from io import StringIO
+        capture = StringIO()
+        handler = logging.StreamHandler(capture)
+        logger.addHandler(handler)
+
+        try:
+            processor = DataProcessor()
+
+            # Mock API client to return valid data
+            mock_client = MagicMock()
+            mock_client.get_seasonal_water_data.return_value = {
+                "timeseries": [
+                    {"year": 2020, "seasons": {"monsoon": {"area_ha": 10, "count": 1}}}
+                ]
+            }
+
+            # Use malicious ID that is technically valid for API client mock but unsafe for terminal
+            processor.load_water_data_from_api(
+                mock_client, [MALICIOUS_ID], 2020, 2021
+            )
+
+            log_output = capture.getvalue()
+
+            # Check debug logs
+            self.assertNotIn("\x1b[", log_output, "ANSI escape sequence found in success logs!")
+            self.assertIn(SANITIZED_ID, log_output, "Sanitized ID not found in success logs")
+
+        finally:
+            logger.removeHandler(handler)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🛡️ Sentinel: Fix Terminal Injection in DataProcessor logs

🚨 Severity: MEDIUM
💡 Vulnerability: User-supplied `location_id` containing ANSI escape sequences was being logged directly to stdout when API validation failed, allowing potential terminal manipulation or log spoofing.
🎯 Impact: Attackers could inject control characters to hide log entries, spoof information, or disrupt terminal output for administrators monitoring the logs.
🔧 Fix: Applied `sanitize_for_terminal` to `location_id` before logging errors or warnings in `DataProcessor.load_water_data_from_api`.
✅ Verification: Added `tests/test_data_processor_security.py` which attempts to inject ANSI codes via a mock API failure and asserts that the logs are clean. All existing tests pass.

---
*PR created automatically by Jules for task [12181269829262530108](https://jules.google.com/task/12181269829262530108) started by @dhruvhaldar*