### PR TITLE
🛡️ Sentinel: [HIGH] Fix password leak in redact_url on parse failure

### DIFF
--- a/ivi_water/security_utils.py
+++ b/ivi_water/security_utils.py
@@ -200,6 +200,18 @@ def redact_url(url: str) -> str:
 
     try:
         parsed = urlparse(url)
+        is_fallback = False
+
+        # If no password found but @ present and no scheme, try fallback parsing
+        if not parsed.password and "@" in url and "://" not in url:
+            try:
+                # Prepend // to treat as netloc-relative URL
+                parsed_fb = urlparse("//" + url)
+                if parsed_fb.password:
+                    parsed = parsed_fb
+                    is_fallback = True
+            except Exception:
+                pass
 
         # Redact password in netloc
         if parsed.password:
@@ -243,12 +255,16 @@ def redact_url(url: str) -> str:
             new_query = urlencode(redacted_params, doseq=True, safe="*")
             parsed = parsed._replace(query=new_query)
 
-        return urlunparse(parsed)
+        # Handle dummy scheme cleanup if fallback was used
+        result = urlunparse(parsed)
+        if is_fallback and result.startswith("//") and not url.startswith("//"):
+            result = result[2:]
+
+        return result
     except Exception:
-        # If parsing fails, return original URL (safer than returning empty or partial)
-        # But for security, maybe we should return a placeholder?
-        # Standard practice is to try best effort.
-        return url
+        # If parsing fails, return a placeholder to prevent leaking secrets
+        # contained in malformed URLs (e.g. invalid ports)
+        return "<REDACTION FAILED>"
 
 
 def validate_safe_id(identifier: str) -> str:

--- a/tests/test_redact_url_vulnerability.py
+++ b/tests/test_redact_url_vulnerability.py
@@ -1,0 +1,47 @@
+
+import pytest
+from ivi_water.security_utils import redact_url
+
+class TestRedactUrlVulnerability:
+    def test_redact_url_invalid_port(self):
+        """Test that invalid ports do not cause password leak."""
+        # URL with invalid port that causes urlparse to fail on some systems/versions
+        # or at least is malformed.
+        # Python's urlparse usually handles invalid ports by treating them as part of netloc or path,
+        # but extremely large ports might raise ValueError in strict parsing or downstream usage.
+        # The reproduction showed this triggered the leak.
+        url = "https://user:secret_password@example.com:999999999999999999"
+        redacted = redact_url(url)
+        assert "secret_password" not in redacted
+        # Should either be redacted or placeholder
+        assert "***REDACTED***" in redacted or "<REDACTION FAILED>" in redacted
+
+    def test_redact_url_no_scheme(self):
+        """Test that URLs without scheme do not cause password leak."""
+        url = "user:secret_password@example.com"
+        redacted = redact_url(url)
+        assert "secret_password" not in redacted
+        assert "***REDACTED***" in redacted
+
+    def test_redact_url_invalid_ipv6(self):
+        """Test that invalid IPv6 addresses do not cause password leak."""
+        url = "https://user:secret_password@[::1]/path"
+        redacted = redact_url(url)
+        assert "secret_password" not in redacted
+        assert "***REDACTED***" in redacted
+
+    def test_redact_url_control_chars(self):
+        """Test that control characters don't cause issues."""
+        url = "https://user:secret_password@example.com/\x00"
+        redacted = redact_url(url)
+        assert "secret_password" not in redacted
+        assert "***REDACTED***" in redacted or "<REDACTION FAILED>" in redacted or redacted == url
+        # If it returns original url but password is NOT leaked (e.g. if password was part of leak), fail.
+        # But here password is clearly visible if returned as is.
+
+    def test_redact_url_complex_leak(self):
+        """Test the reproduction case explicitly."""
+        url = "https://user:password@example.com:999999999999999999"
+        redacted = redact_url(url)
+        assert "password" not in redacted.split("@")[0] # Check password part specifically
+        # 'password' is the password here.

--- a/tests/test_redact_url_vulnerability.py
+++ b/tests/test_redact_url_vulnerability.py
@@ -35,9 +35,7 @@ class TestRedactUrlVulnerability:
         url = "https://user:secret_password@example.com/\x00"
         redacted = redact_url(url)
         assert "secret_password" not in redacted
-        assert "***REDACTED***" in redacted or "<REDACTION FAILED>" in redacted or redacted == url
-        # If it returns original url but password is NOT leaked (e.g. if password was part of leak), fail.
-        # But here password is clearly visible if returned as is.
+        assert "***REDACTED***" in redacted or "<REDACTION FAILED>" in redacted
 
     def test_redact_url_complex_leak(self):
         """Test the reproduction case explicitly."""


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: `redact_url` in `ivi_water/security_utils.py` leaked the full URL, including credentials, when `urllib.parse.urlparse` raised an exception (e.g., due to an invalid port number) or failed to identify the password component (e.g., in schemeless URLs like `user:pass@host`). This violates the "Fail Securely" principle.

🎯 Impact: Sensitive credentials (passwords, tokens) embedded in malformed connection strings could be exposed in logs or error messages.

🔧 Fix:
-   Modified `redact_url` to return a safe placeholder `<REDACTION FAILED>` instead of the original URL upon exception.
-   Added fallback logic to prepend `//` to schemeless URLs containing `@`, forcing `urlparse` to recognize the `netloc` and identify credentials for redaction.

✅ Verification:
-   Added `tests/test_redact_url_vulnerability.py` covering invalid ports and schemeless URLs.
-   Ran existing test suite to ensure no regressions.

---
*PR created automatically by Jules for task [10943647803151677700](https://jules.google.com/task/10943647803151677700) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents sensitive data leakage for malformed or edge-case URLs by returning a safe placeholder on parse failure.
  * Improves credential redaction for URLs lacking schemes or with unusual formatting, including cleanup of extraneous leading slashes after fallback parsing.

* **Tests**
  * Added comprehensive tests covering malformed URLs, invalid ports/IPs, control characters, and other edge cases to ensure redaction integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->