### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Terminal Injection in DataProcessor logs

### DIFF
--- a/ivi_water/data_processor.py
+++ b/ivi_water/data_processor.py
@@ -878,9 +878,15 @@ class DataProcessor:
                     invalid_values = df_clean.loc[
                         relevant_invalid_mask, "intervention_type"
                     ].unique()
+
+                    # Sanitize values before logging to prevent terminal injection
+                    safe_invalid_values = [
+                        sanitize_for_terminal(str(v)) for v in invalid_values
+                    ]
+
                     self.logger.warning(
                         f"Found {relevant_invalid_mask.sum()} records with unrecognized intervention types: "
-                        f"{invalid_values}"
+                        f"{safe_invalid_values}"
                     )
                     # Keep them but log the issue
 
@@ -944,7 +950,12 @@ class DataProcessor:
                 intervention_stats = (
                     df_clean["intervention_type"].value_counts().to_dict()
                 )
-                self.logger.info(f"Intervention types: {intervention_stats}")
+                # Sanitize keys to prevent terminal injection
+                safe_stats = {
+                    sanitize_for_terminal(str(k)): v
+                    for k, v in intervention_stats.items()
+                }
+                self.logger.info(f"Intervention types: {safe_stats}")
 
             # Warn if too much data was removed
             if removal_rate > 50:

--- a/tests/test_data_processor_security.py
+++ b/tests/test_data_processor_security.py
@@ -1,6 +1,7 @@
 
 import logging
 import unittest
+import pandas as pd
 from unittest.mock import MagicMock
 from ivi_water.data_processor import DataProcessor
 from ivi_water.security_utils import sanitize_for_terminal
@@ -90,6 +91,45 @@ class TestDataProcessorSecurity(unittest.TestCase):
             # Check debug logs
             self.assertNotIn("\x1b[", log_output, "ANSI escape sequence found in success logs!")
             self.assertIn(SANITIZED_ID, log_output, "Sanitized ID not found in success logs")
+
+        finally:
+            logger.removeHandler(handler)
+
+    def test_nrm_data_log_injection(self):
+        """
+        Verify that user inputs in NRM data (intervention types) are sanitized before logging.
+        """
+        # Setup capturing logger
+        logger = logging.getLogger("ivi_water.data_processor")
+        logger.setLevel(logging.INFO)
+
+        from io import StringIO
+        capture = StringIO()
+        handler = logging.StreamHandler(capture)
+        logger.addHandler(handler)
+
+        try:
+            processor = DataProcessor()
+
+            # Create DataFrame with ANSI escape sequence in intervention_type
+            malicious_type = "\x1b[31mmalicious_type\x1b[0m"
+            sanitized_type = sanitize_for_terminal(malicious_type)
+
+            df = pd.DataFrame({
+                'location_id': ['V001'],
+                'year': [2020],
+                'intervention_type': [malicious_type],
+                'pond_presence': [0]
+            })
+
+            # Call _clean_nrm_data
+            processor._clean_nrm_data(df)
+
+            log_output = capture.getvalue()
+
+            # Check logs
+            self.assertNotIn("\x1b[", log_output, "ANSI escape sequence found in NRM logs!")
+            self.assertIn(sanitized_type, log_output, "Sanitized intervention type not found in NRM logs")
 
         finally:
             logger.removeHandler(handler)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Terminal Injection (Log Injection). The `DataProcessor` was logging user-provided `intervention_type` values directly from NRM impact data CSVs without sanitization. This allowed malicious input containing ANSI escape sequences to manipulate terminal output or logs.
🎯 **Impact:** Attackers could spoof log entries, hide critical information, or potentially exploit vulnerable terminal emulators if the logs are viewed in a terminal.
🔧 **Fix:** Applied `sanitize_for_terminal` to all `intervention_type` values and statistics keys before passing them to the logger in `_clean_nrm_data`.
✅ **Verification:** Added `tests/test_data_processor_security.py::test_nrm_data_log_injection` which asserts that ANSI codes are stripped from log output. Verified with `repro_terminal_injection.py`.

---
*PR created automatically by Jules for task [3144087123371007667](https://jules.google.com/task/3144087123371007667) started by @dhruvhaldar*