### PR TITLE
🛡️ Sentinel: [security improvement] Fix over-redaction and preserve auth schemes

### DIFF
--- a/ivi_water/security_utils.py
+++ b/ivi_water/security_utils.py
@@ -363,6 +363,7 @@ def redact_text_content(text: str) -> str:
     # We handle quoted values specially
 
     # 1. Match quoted values: key="value with spaces"
+    # Note: pattern_quoted is legacy/unused in favor of pattern_double/single below
     pattern_quoted = re.compile(
         r"(?i)\b(" + keys_pattern + r')\b\s*[:=]\s*(["\'])(.*?)\2', re.DOTALL
     )
@@ -393,15 +394,21 @@ def redact_text_content(text: str) -> str:
 
     # 1. Double quotes: "value" - handles escaped double quotes \" and truncated strings
     # We use \\.? to handle escaped characters, including if the string is truncated right after backslash
+    # Added \b (word boundary) to prevent matching keys as suffixes (e.g. skey="val" matching key)
     pattern_double = re.compile(
-        r'(?i)(["\']?)(' + keys_pattern + r')\1(\s*[:=]\s*)(")((?:[^"\\]|\\.?)*)(?:"|$)',
+        r'(?i)(["\']?)\b('
+        + keys_pattern
+        + r')\1(\s*[:=]\s*)(")((?:[^"\\]|\\.?)*)(?:"|$)',
         re.DOTALL,
     )
     text = pattern_double.sub(r'\1\2\1\3"***REDACTED***"', text)
 
     # 2. Single quotes: 'value' - handles escaped single quotes \' and truncated strings
+    # Added \b (word boundary) to prevent matching keys as suffixes
     pattern_single = re.compile(
-        r'(?i)(["\']?)(' + keys_pattern + r")\1(\s*[:=]\s*)(\')((?:[^\'\\]|\\.?)*)(?:'|$)",
+        r'(?i)(["\']?)\b('
+        + keys_pattern
+        + r")\1(\s*[:=]\s*)(\')((?:[^\'\\]|\\.?)*)(?:'|$)",
         re.DOTALL,
     )
     # Note: Use plain string with ' for replacement to avoid double escaping issues
@@ -429,9 +436,12 @@ def redact_text_content(text: str) -> str:
         re.DOTALL,
     )
 
-    # Replace with: \1\2\1\3\4***REDACTED***
+    # Replace with: \1\2_IVIPROTECTED_\1\3\4***REDACTED***
+    # We append _IVIPROTECTED_ to the key to prevent subsequent generic patterns
+    # (which use \b word boundary) from matching 'Authorization_IVIPROTECTED_'
+    # and re-redacting the preserved scheme.
     # \1 (Quote), \2 (Key), \1 (Quote Match), \3 (Separator), \4 (Scheme+Space)
-    text = pattern_auth.sub(r"\1\2\1\3\4***REDACTED***", text)
+    text = pattern_auth.sub(r"\1\2_IVIPROTECTED_\1\3\4***REDACTED***", text)
 
     # 4. For unquoted: Replace group 4 (value) with ***REDACTED***
     # Group 1: Optional Quote
@@ -442,8 +452,12 @@ def redact_text_content(text: str) -> str:
     # 3. Unquoted values with '=' (strict whitespace termination)
     # Handles query params, shell-style (key=value next=val)
     # Stops at whitespace, comma, semicolon, braces/brackets
+    # Added \b (word boundary) to prevent matching keys as suffixes
     pattern_unquoted_equals = re.compile(
-        r'(?i)(["\']?)(' + keys_pattern + r')\1(\s*=\s*)([^"\'\s,;}\]]+)', re.DOTALL
+        r'(?i)(["\']?)\b('
+        + keys_pattern
+        + r')\1(\s*=\s*)([^"\'\s,;}\]]+)',
+        re.DOTALL,
     )
     text = pattern_unquoted_equals.sub(r"\1\2\1\3***REDACTED***", text)
 
@@ -453,10 +467,17 @@ def redact_text_content(text: str) -> str:
     # Explicitly excludes newlines (\n\r) to prevent multi-line consumption
     # Uses lookahead (?=\S) to ensure value starts with non-whitespace, preventing
     # matches on just the space before a quoted value (e.g. "key": "value")
+    # Added \b (word boundary) to prevent matching keys as suffixes
     pattern_unquoted_colon = re.compile(
-        r'(?i)(["\']?)(' + keys_pattern + r')\1(\s*:\s*)(?=\S)([^"\'\n\r,;}\]]+)', re.DOTALL
+        r'(?i)(["\']?)\b('
+        + keys_pattern
+        + r')\1(\s*:\s*)(?=\S)([^"\'\n\r,;}\]]+)',
+        re.DOTALL,
     )
     text = pattern_unquoted_colon.sub(r"\1\2\1\3***REDACTED***", text)
+
+    # Restore Authorization keys by removing the protection suffix
+    text = text.replace("_IVIPROTECTED_", "")
 
     return text
 

--- a/tests/test_redact_text.py
+++ b/tests/test_redact_text.py
@@ -62,7 +62,7 @@ def test_authorization_header_redaction():
     redacted = redact_text_content(header)
     assert "secret_token_12345" not in redacted
     assert "***REDACTED***" in redacted
-    assert "Bearer" not in redacted  # It's part of the value, so it should be redacted
+    assert "Bearer" in redacted  # The scheme should be preserved for debugging
 
 
 def test_key_value_with_spaces_colon():
@@ -88,3 +88,18 @@ def test_json_like_string_unquoted():
     redacted = redact_text_content(text)
     assert "secret value" not in redacted
     assert "other" in redacted
+
+
+def test_suffix_key_preservation():
+    # keys matching as suffix of other words should not trigger redaction
+    # 'key' is sensitive, but 'monkey' should be preserved
+    text = 'monkey="banana"'
+    redacted = redact_text_content(text)
+    assert 'monkey="banana"' in redacted
+    assert "***REDACTED***" not in redacted
+
+    # 'token' is sensitive, but 'public_token' (if not in sensitive list) should ideally be preserved
+    # 'public_token' ends with 'token'. '_' is a word char, so \b does not match.
+    text = 'public_token="safe"'
+    redacted = redact_text_content(text)
+    assert 'public_token="safe"' in redacted


### PR DESCRIPTION
🛡️ Sentinel Security Improvement

**Summary:**
This PR improves the `redact_text_content` security utility to prevent over-redaction and log corruption. It addresses two main issues:
1.  **Suffix Matching (False Positives):** Previously, generic redaction patterns matched keys as substrings (e.g., `key` matches `monkey="banana"`), leading to corrupted logs (`mon"***REDACTED***"`). This is fixed by enforcing word boundaries (`\b`).
2.  **Authentication Scheme Hiding:** Redaction of `Authorization` headers previously hid the authentication scheme (e.g., `Bearer`, `Basic`) due to fallback to generic patterns. A new protection mechanism (`_IVIPROTECTED_` suffix) preserves the scheme while ensuring the token remains redacted, improving debugging capability without compromising security.

**Changes:**
-   Modified `ivi_water/security_utils.py`:
    -   Added `\b` to `pattern_double`, `pattern_single`, `pattern_unquoted_equals`, `pattern_unquoted_colon`.
    -   Implemented `_IVIPROTECTED_` placeholder logic for `Authorization` keys.
-   Updated `tests/test_redact_text.py`:
    -   Updated `test_authorization_header_redaction` to assert scheme preservation.
    -   Added `test_suffix_key_preservation`.

**Verification:**
-   Added reproduction script `debug_regex.py` (verified pass).
-   Ran full test suite (`pytest`), all tests passed.


---
*PR created automatically by Jules for task [1422527723722832841](https://jules.google.com/task/1422527723722832841) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved sensitive data redaction pattern accuracy to prevent false positive matches where key identifiers appear as suffixes within larger words.
* Enhanced redaction reliability by preventing re-processing of previously redacted content.

## Tests
* Added test coverage for key pattern matching edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->