### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSP bypass via automatic source whitelisting

### DIFF
--- a/ivi_water/security_utils.py
+++ b/ivi_water/security_utils.py
@@ -9,6 +9,8 @@ import re
 import hmac
 import hashlib
 import base64
+import os
+import logging
 from html.parser import HTMLParser
 from typing import Dict, Any, Union, List, Optional
 from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
@@ -66,6 +68,11 @@ MAX_ID_LENGTH = 128
 # - Images: 'self' and data: URIs (For embedded plots)
 # Blocks everything else (default-src 'none') to prevent XSS/exfiltration
 CSP_META_CONTENT = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self' data:;"
+
+# Allowed domains for scripts in CSP
+DEFAULT_ALLOWED_SCRIPT_DOMAINS = {
+    "cdn.plot.ly",
+}
 
 # --- Pre-compiled Regex Patterns (Performance Optimization) ---
 
@@ -429,6 +436,7 @@ def inject_csp_meta_tag(html_content: str) -> str:
     strict security controls, preventing XSS and data exfiltration.
 
     It calculates SHA-256 hashes for inline scripts to avoid 'unsafe-inline'.
+    It restricts external script sources to a safe whitelist.
 
     Args:
         html_content: The original HTML string.
@@ -452,7 +460,36 @@ def inject_csp_meta_tag(html_content: str) -> str:
 
         # Add allowed sources (CDNs)
         if parser.sources:
-            script_srcs.extend(sorted(list(parser.sources)))
+            # Enforce whitelist for external script sources
+            allowed_domains = DEFAULT_ALLOWED_SCRIPT_DOMAINS.copy()
+
+            # Allow user to extend whitelist via environment variable
+            env_allowed = os.getenv("IVI_CSP_ALLOWED_DOMAINS")
+            if env_allowed:
+                allowed_domains.update(
+                    [d.strip() for d in env_allowed.split(",") if d.strip()]
+                )
+
+            logger = logging.getLogger(__name__)
+
+            for source in parser.sources:
+                # Extract hostname from source URL
+                try:
+                    # urlparse returns netloc (e.g., example.com:8080)
+                    # We use hostname to ignore port (e.g., example.com)
+                    # Use lower() for case-insensitive comparison
+                    parsed_source = urlparse(source)
+                    source_hostname = (parsed_source.hostname or "").lower()
+
+                    if source_hostname in allowed_domains:
+                        script_srcs.append(source)
+                    else:
+                        logger.warning(
+                            f"Blocked unauthorized script source in CSP: {source_hostname} ({source}). "
+                            "To allow, set IVI_CSP_ALLOWED_DOMAINS environment variable."
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to parse script source {source}: {e}")
 
         script_policy = " ".join(script_srcs)
 

--- a/tests/test_csp_vulnerability.py
+++ b/tests/test_csp_vulnerability.py
@@ -1,0 +1,86 @@
+
+import os
+import re
+import pytest
+from unittest.mock import patch
+from ivi_water.security_utils import inject_csp_meta_tag
+
+class TestCSPVulnerability:
+    def _extract_csp(self, html_content):
+        """Helper to extract CSP string from meta tag."""
+        # Finds <meta http-equiv="Content-Security-Policy" content="...">
+        # Note: Using regex for simplicity in test helper
+        match = re.search(r'<meta http-equiv="Content-Security-Policy" content="(.*?)">', html_content)
+        if match:
+            return match.group(1)
+        return ""
+
+    def test_csp_blocks_arbitrary_source(self):
+        """
+        Verify that inject_csp_meta_tag blocks unauthorized script sources
+        found in the HTML.
+        """
+        malicious_html = """
+        <html>
+        <head></head>
+        <body>
+            <h1>Report</h1>
+            <script src="https://evil-attacker.com/payload.js"></script>
+        </body>
+        </html>
+        """
+
+        secure_html = inject_csp_meta_tag(malicious_html)
+        csp = self._extract_csp(secure_html)
+
+        # Evil domain should NOT be in the CSP
+        # ScriptHasher extracts origin, so check for origin
+        assert "https://evil-attacker.com" not in csp
+        assert "evil-attacker.com" not in csp
+
+        # 'self' should be there
+        assert "script-src" in csp
+        assert "'self'" in csp
+
+    def test_csp_allows_whitelisted_source(self):
+        """
+        Verify that inject_csp_meta_tag allows whitelisted sources (e.g. cdn.plot.ly).
+        """
+        valid_html = """
+        <html>
+        <head></head>
+        <body>
+            <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+        </body>
+        </html>
+        """
+
+        secure_html = inject_csp_meta_tag(valid_html)
+        csp = self._extract_csp(secure_html)
+
+        # Whitelisted domain origin SHOULD be in the CSP
+        assert "https://cdn.plot.ly" in csp
+
+    def test_csp_allows_env_extension(self):
+        """
+        Verify that users can extend the whitelist via environment variable.
+        """
+        custom_html = """
+        <html>
+        <head></head>
+        <body>
+            <script src="https://trusted-partner.com/lib.js"></script>
+        </body>
+        </html>
+        """
+
+        # Without env var, it should be blocked
+        secure_html_blocked = inject_csp_meta_tag(custom_html)
+        csp_blocked = self._extract_csp(secure_html_blocked)
+        assert "https://trusted-partner.com" not in csp_blocked
+
+        # With env var, it should be allowed
+        with patch.dict(os.environ, {"IVI_CSP_ALLOWED_DOMAINS": "trusted-partner.com, other-domain.com"}):
+            secure_html_allowed = inject_csp_meta_tag(custom_html)
+            csp_allowed = self._extract_csp(secure_html_allowed)
+            assert "https://trusted-partner.com" in csp_allowed


### PR DESCRIPTION
This PR fixes a security vulnerability in the Content Security Policy (CSP) generation logic where any script source found in the HTML was automatically whitelists. This behavior could allow an attacker to bypass CSP by injecting a `<script src="...">` tag.

The fix enforces a strict whitelist of allowed domains (defaulting to `cdn.plot.ly`) and provides an environment variable `IVI_CSP_ALLOWED_DOMAINS` for users to allow additional trusted domains if necessary.

Changes:
- Modified `ivi_water/security_utils.py` to filter script sources against a whitelist.
- Added `DEFAULT_ALLOWED_SCRIPT_DOMAINS`.
- Added logging for blocked script sources.
- Added `tests/test_csp_vulnerability.py` to verify the fix.

---
*PR created automatically by Jules for task [2955843623011998731](https://jules.google.com/task/2955843623011998731) started by @dhruvhaldar*