### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix redaction bypass for hyphenated URL parameters

### DIFF
--- a/ivi_water/security_utils.py
+++ b/ivi_water/security_utils.py
@@ -309,8 +309,10 @@ def redact_url(url: str) -> str:
                     is_sensitive = True
                 else:
                     for sensitive in SENSITIVE_KEYS:
-                        if key_lower == sensitive or key_lower.endswith(
-                            f"_{sensitive}"
+                        if (
+                            key_lower == sensitive
+                            or key_lower.endswith(f"_{sensitive}")
+                            or key_lower.endswith(f"-{sensitive}")
                         ):
                             is_sensitive = True
                             break

--- a/tests/test_redact_url_suffix.py
+++ b/tests/test_redact_url_suffix.py
@@ -1,0 +1,46 @@
+
+import pytest
+from ivi_water.security_utils import redact_url
+
+class TestRedactUrlSuffix:
+    def test_redact_url_exact_match(self):
+        """Test exact match for sensitive keys."""
+        url = "http://example.com/api?api_key=secret"
+        redacted = redact_url(url)
+        assert "api_key=***REDACTED***" in redacted
+        assert "secret" not in redacted
+
+    def test_redact_url_underscore_suffix(self):
+        """Test underscore suffix match."""
+        url = "http://example.com/api?my_api_key=secret"
+        redacted = redact_url(url)
+        assert "my_api_key=***REDACTED***" in redacted
+        assert "secret" not in redacted
+
+    def test_redact_url_hyphen_suffix(self):
+        """Test hyphen suffix match (The Fix)."""
+        url = "http://example.com/api?my-api-key=secret"
+        redacted = redact_url(url)
+        assert "my-api-key=***REDACTED***" in redacted
+        assert "secret" not in redacted
+
+    def test_redact_url_no_suffix_match(self):
+        """Test that keys without separator suffix do not match if not exact."""
+        # 'public_key' is sensitive.
+        # 'republic_key' ends with '_key' which is sensitive 'key' with separator.
+        # But 'monkey' ends with 'key' WITHOUT separator.
+
+        # 'key' is in SENSITIVE_KEYS.
+        # 'monkey' should NOT be redacted.
+        url = "http://example.com/api?monkey=banana"
+        redacted = redact_url(url)
+        assert "monkey=banana" in redacted
+
+    def test_redact_url_mixed_separators(self):
+        """Test mixed separators."""
+        # 'client-secret' is sensitive.
+        # 'my_client-secret' -> ends with '_client-secret'.
+        url = "http://example.com/api?my_client-secret=top_secret"
+        redacted = redact_url(url)
+        assert "my_client-secret=***REDACTED***" in redacted
+        assert "top_secret" not in redacted


### PR DESCRIPTION
This PR fixes a security inconsistency where `redact_url` failed to redact sensitive query parameters that used a hyphenated suffix (e.g., `my-api-key`), whereas `redact_sensitive_data` correctly handled them.

### Changes
- Updated `ivi_water/security_utils.py`: `redact_url` now checks for keys ending with `-{sensitive_key}` (e.g. `my-api-key`) in addition to `_{sensitive_key}`.
- Added `tests/test_redact_url_suffix.py`: Comprehensive tests for URL redaction with various suffixes.

### Verification
- Verified with reproduction script `reproduce_redaction_gap.py`.
- Ran full test suite (`python3 -m pytest`), all tests passed.


---
*PR created automatically by Jules for task [16778725587498079155](https://jules.google.com/task/16778725587498079155) started by @dhruvhaldar*