### PR TITLE
🎨 Palette: [UX improvement] Add `<title>` to Plotly HTML exports

### DIFF
--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -834,6 +834,12 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
+                        # Add title for accessibility
+                        html_content = html_content.replace(
+                            "<head>",
+                            "<head>\n    <title>Water Trends Visualization</title>",
+                        )
+
                         from .security_utils import inject_csp_meta_tag
 
                         html_content = inject_csp_meta_tag(html_content)

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -712,6 +712,11 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
+            # Add title for accessibility
+            html_content = html_content.replace(
+                "<head>", "<head>\n    <title>Water Trends Dashboard</title>"
+            )
+
             # Inject CSP meta tag for security
             from .security_utils import inject_csp_meta_tag
 
@@ -811,6 +816,11 @@ class WaterTrendsVisualizer:
 
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
+
+            # Add title for accessibility
+            html_content = html_content.replace(
+                "<head>", "<head>\n    <title>Water Trends Visualization</title>"
+            )
 
             # Inject CSP meta tag for security
             from .security_utils import inject_csp_meta_tag


### PR DESCRIPTION
💡 What: Added `<title>Water Trends Dashboard</title>` and `<title>Water Trends Visualization</title>` into the HTML outputs generated via Plotly's `to_html()` in `ivi_water/visualizer.py` and `ivi_water/export_utils.py`.

🎯 Why: Plotly's `to_html()` generates `<html>` and `<head>` tags but does not include a meaningful `<title>` tag. This makes it difficult for screen reader users and users with many open tabs to identify the purpose of the exported chart or dashboard.

📸 Before/After:
Before: HTML files only had `<html lang="en"><head>...`
After: HTML files now have `<html lang="en"><head><title>Water Trends Visualization</title>...`

♿ Accessibility: Ensures that screen readers immediately announce the document title upon loading the HTML report or dashboard, fulfilling a core WCAG requirement.

---
*PR created automatically by Jules for task [15959968180199609022](https://jules.google.com/task/15959968180199609022) started by @dhruvhaldar*