### PR TITLE
🎨 Palette: [Mobile responsiveness for Plotly exports]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2023-10-25 - HTML Report Accessibility
 **Learning:** Generated HTML reports lacked viewport meta tags and semantic structure, making them poorly responsive on mobile and harder for screen readers to navigate.
 **Action:** Added `<meta name="viewport">` for mobile responsiveness and semantic HTML tags (`<main>`, `<header>`, `<section>`) with `aria-labelledby` to improve screen reader navigation.
+## 2025-03-26 - Interactive Plotly HTML Mobile Responsiveness
+**Learning:** Plotly's `to_html()` default exports lack viewport meta tags, causing interactive charts to appear zoomed out or require pinching on mobile devices, diminishing the responsive experience.
+**Action:** Injected `<meta name="viewport" content="width=device-width, initial-scale=1.0">` alongside title injection when generating HTML exports from Plotly figures to ensure correct mobile scaling.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -834,10 +834,10 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
-                        # Add title for accessibility
+                        # Add title for accessibility and viewport meta tag for mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            "<head>\n    <title>Water Trends Visualization</title>",
+                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
                         )
 
                         from .security_utils import inject_csp_meta_tag

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -712,9 +712,10 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title for accessibility
+            # Add title for accessibility and viewport meta tag for mobile responsiveness
             html_content = html_content.replace(
-                "<head>", "<head>\n    <title>Water Trends Dashboard</title>"
+                "<head>",
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
             )
 
             # Inject CSP meta tag for security
@@ -817,9 +818,10 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title for accessibility
+            # Add title for accessibility and viewport meta tag for mobile responsiveness
             html_content = html_content.replace(
-                "<head>", "<head>\n    <title>Water Trends Visualization</title>"
+                "<head>",
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
             )
 
             # Inject CSP meta tag for security


### PR DESCRIPTION
💡 **What:** Injected a `<meta name="viewport" content="width=device-width, initial-scale=1.0">` tag into the `<head>` of HTML visualizations and reports generated by Plotly's `to_html()`. 

🎯 **Why:** Plotly's default HTML exports do not include viewport tags, which results in interactive charts appearing zoomed-out and requiring users to pinch/zoom on mobile devices. This simple injection allows the charts to properly scale and flow based on the device width, significantly improving the responsive experience.

📸 **Before/After:** Before, HTML files on mobile devices required zooming to be legible. Now, the charts automatically adjust their layout correctly on mobile viewports.

♿ **Accessibility:** This also enhances mobile accessibility, ensuring elements (like tooltips and legends) are properly sized and readable without extra user interaction. Additionally, recorded this learning in the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [9451648852062593357](https://jules.google.com/task/9451648852062593357) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exported HTML charts now display with improved mobile device responsiveness and proper scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->