### PR TITLE
🎨 Palette: Add viewport meta tag for mobile responsiveness

### DIFF
--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -834,10 +834,10 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
-                        # Add title for accessibility
+                        # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            "<head>\n    <title>Water Trends Visualization</title>",
+                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
                         )
 
                         from .security_utils import inject_csp_meta_tag

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -712,9 +712,10 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title for accessibility
+            # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
-                "<head>", "<head>\n    <title>Water Trends Dashboard</title>"
+                "<head>",
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
             )
 
             # Inject CSP meta tag for security
@@ -817,9 +818,10 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title for accessibility
+            # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
-                "<head>", "<head>\n    <title>Water Trends Visualization</title>"
+                "<head>",
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
             )
 
             # Inject CSP meta tag for security


### PR DESCRIPTION
💡 **What:** Added `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to all generated HTML reports and visualizations.
🎯 **Why:** Plotly's `to_html` function does not include a viewport meta tag by default, causing exported HTML files to look zoomed out or incorrectly scaled on mobile devices.
📸 **Before/After:** Before, HTML files on mobile required pinching and zooming to read text. After, they scale correctly to the device width.
♿ **Accessibility:** This improves mobile accessibility by ensuring text remains readable and layouts are responsive without requiring manual zooming by the user.

---
*PR created automatically by Jules for task [34354659549005650](https://jules.google.com/task/34354659549005650) started by @dhruvhaldar*