### PR TITLE
🎨 Palette: Add skip-to-content link to HTML reports

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2023-10-25 - HTML Report Accessibility
 **Learning:** Generated HTML reports lacked viewport meta tags and semantic structure, making them poorly responsive on mobile and harder for screen readers to navigate.
 **Action:** Added `<meta name="viewport">` for mobile responsiveness and semantic HTML tags (`<main>`, `<header>`, `<section>`) with `aria-labelledby` to improve screen reader navigation.
+## 2024-05-15 - HTML Report Skip-to-Content Link
+**Learning:** Generated HTML reports with large header or banner sections force screen reader users to listen to repetitive navigation/header content on every view, leading to a frustrating experience.
+**Action:** Added a visually hidden "Skip to main content" link at the very top of the `<body>` that becomes visible on `:focus`. This allows keyboard and screen reader users to bypass the header and immediately access the main report data (`#summary-stats-title`).

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -547,9 +547,22 @@ class ExportUtils:
                 th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
                 th {{ background-color: #f2f2f2; font-weight: bold; }}
                 .summary {{ background-color: #f8f9fa; padding: 15px; border-radius: 5px; }}
+                .skip-link {{
+                    position: absolute;
+                    top: -40px;
+                    left: 0;
+                    background: #3498db;
+                    color: white;
+                    padding: 8px;
+                    z-index: 100;
+                    transition: top 0.2s;
+                    text-decoration: none;
+                }}
+                .skip-link:focus {{ top: 0; }}
             </style>
         </head>
         <body>
+            <a href="#summary-stats-title" class="skip-link">Skip to main content</a>
             <main>
                 <header>
                     <h1>Water Trends Summary Report</h1>


### PR DESCRIPTION
### 💡 What
Added a "Skip to main content" link to the HTML report generator in `ivi_water/export_utils.py`. The link is visually hidden by default but becomes visible when it receives keyboard focus.

### 🎯 Why
Generated HTML reports with large headers can be frustrating for keyboard-only and screen reader users, who otherwise have to tab through repetitive header content on every view before reaching the main data.

### 📸 Before/After
*   **Before:** Users navigating via keyboard/screen reader would start at the top of the document and tab through all `<header>` content before reaching the data tables.
*   **After:** The first focusable element is a "Skip to main content" link that immediately jumps focus to `#summary-stats-title`, bypassing the header.

### ♿ Accessibility
*   **Keyboard Navigation:** Provides a direct bypass block for keyboard users (WCAG 2.4.1 Bypass Blocks).
*   **Screen Readers:** Enhances screen reader efficiency by allowing users to skip repetitive navigation/header landmarks.

---
*PR created automatically by Jules for task [6588425404218927895](https://jules.google.com/task/6588425404218927895) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a skip link enabling direct navigation to the main content section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->