### PR TITLE
🎨 Palette: [UX improvement] Fix color contrast for skip-to-content link in HTML report

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-15 - HTML Report Skip-to-Content Link
 **Learning:** Generated HTML reports with large header or banner sections force screen reader users to listen to repetitive navigation/header content on every view, leading to a frustrating experience.
 **Action:** Added a visually hidden "Skip to main content" link at the very top of the `<body>` that becomes visible on `:focus`. This allows keyboard and screen reader users to bypass the header and immediately access the main report data (`#summary-stats-title`).
+## 2026-03-29 - Color Contrast on Interactive Elements
+**Learning:** The skip-to-content link and section headers used a light blue (`#3498db`) that failed WCAG 2.1 AA color contrast requirements (3.15:1) against white, making it hard to read for users with visual impairments.
+**Action:** Darkened the background color to `#226699` to ensure a 6.1:1 contrast ratio, ensuring accessibility for all interactive elements and visual dividers.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -542,7 +542,7 @@ class ExportUtils:
             <style>
                 body {{ font-family: Arial, sans-serif; margin: 40px; }}
                 h1 {{ color: #2c3e50; text-align: center; }}
-                h2 {{ color: #34495e; border-bottom: 2px solid #3498db; }}
+                h2 {{ color: #34495e; border-bottom: 2px solid #226699; }}
                 table {{ border-collapse: collapse; width: 100%; margin: 20px 0; }}
                 th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
                 th {{ background-color: #f2f2f2; font-weight: bold; }}
@@ -551,7 +551,7 @@ class ExportUtils:
                     position: absolute;
                     top: -40px;
                     left: 0;
-                    background: #3498db;
+                    background: #226699;
                     color: white;
                     padding: 8px;
                     z-index: 100;


### PR DESCRIPTION
💡 **What:** Darkened the background color of the skip-to-content link and the `h2` border-bottom from `#3498db` to `#226699` in `ivi_water/export_utils.py`.
🎯 **Why:** To improve accessibility for users with visual impairments. The previous light blue color against white text yielded a contrast ratio of ~3.15:1, failing WCAG AA standards. The new darker blue ensures a 6.1:1 contrast ratio.
📸 **Before/After:** The visual difference is a slightly darker shade of blue on the hidden "Skip to main content" link (when focused) and the underline for section headers in the generated HTML reports.
♿ **Accessibility:** Fixes a WCAG 2.1 AA color contrast failure for interactive elements and visual dividers, improving screen reader user experience.

---
*PR created automatically by Jules for task [8701297251646628200](https://jules.google.com/task/8701297251646628200) started by @dhruvhaldar*