### PR TITLE
🎨 Palette: [UX improvement] Use accessible color palette for data visualizations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2026-03-29 - Color Contrast on Interactive Elements
 **Learning:** The skip-to-content link and section headers used a light blue (`#3498db`) that failed WCAG 2.1 AA color contrast requirements (3.15:1) against white, making it hard to read for users with visual impairments.
 **Action:** Darkened the background color to `#226699` to ensure a 6.1:1 contrast ratio, ensuring accessibility for all interactive elements and visual dividers.
+## 2024-06-18 - Color-blind Accessibility for Data Visualization
+**Learning:** The use of standard red (`#ff6b6b`) and green (`#51cf66`) for comparative charts (With/Without Intervention) creates issues for red-green colorblind users (Deuteranomaly/Protanomaly) and fails WCAG AA contrast ratios against white backgrounds.
+**Action:** Replaced the red/green paired colors with a higher-contrast, color-blind friendly scheme using red (`#d62728`) and blue (`#1f77b4`), applying it via `color_discrete_map` to consistently handle accessibility across charts.

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -394,6 +394,10 @@ class WaterTrendsVisualizer:
             x="year",
             y="water_area_ha",
             color=intervention_col,
+            color_discrete_map={
+                "Without Intervention": "#d62728",
+                "With Intervention": "#1f77b4",
+            },
             title=safe_title,
             labels={
                 "water_area_ha": "Average Water Area (hectares)",
@@ -404,10 +408,6 @@ class WaterTrendsVisualizer:
         )
 
         fig.update_layout(height=self.height, width=self.width, hovermode="x unified")
-
-        # Customize colors
-        fig.data[0].line.color = "#ff6b6b"  # Red for without intervention
-        fig.data[1].line.color = "#51cf66"  # Green for with intervention
 
         return fig
 
@@ -574,6 +574,10 @@ class WaterTrendsVisualizer:
             x="water_area_ha",
             y=impact_col,
             color="intervention_status",
+            color_discrete_map={
+                "Without Intervention": "#d62728",
+                "With Intervention": "#1f77b4",
+            },
             title=safe_title,
             labels={
                 "water_area_ha": "Water Area (hectares)",


### PR DESCRIPTION
💡 **What:** Replaced the hard-coded standard red/green colors for the "With Intervention" vs "Without Intervention" chart plots with an accessible red (`#d62728`) and blue (`#1f77b4`) palette via Plotly's `color_discrete_map` attribute.

🎯 **Why:** Standard red/green contrast often fails WCAG AA contrast ratio requirements and causes difficulty for users with Deuteranomaly and Protanomaly color blindness. The change also robustly explicitly maps labels to colors (via `color_discrete_map`) rather than relying on trace indexes.

📸 **Before/After:**
- **Before:** "Without Intervention" line was `#ff6b6b`, "With Intervention" line was `#51cf66`. Scatter plot points used default plotly colors (since colors were not defined).
- **After:** Both line and scatter plots consistently use `#d62728` for "Without Intervention" and `#1f77b4` for "With Intervention" and colors are explicitly mapped.

♿ **Accessibility:** Solves red-green color blindness issues and improves the contrast ratio of the plotted datasets against a white background to greater than 3:1 (passing WCAG 2.1 AA requirements).

---
*PR created automatically by Jules for task [11566316493474389476](https://jules.google.com/task/11566316493474389476) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation entry describing accessibility updates for data visualizations with revised color schemes.

* **Refactor**
  * Refactored color assignment mechanisms in visualizations to ensure consistent application of an accessibility-friendly red/blue color scheme across all comparison and scatter plot charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->