### PR TITLE
🎨 Palette: [UX improvement] Responsive HTML tables and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-06-18 - Color-blind Accessibility for Data Visualization
 **Learning:** The use of standard red (`#ff6b6b`) and green (`#51cf66`) for comparative charts (With/Without Intervention) creates issues for red-green colorblind users (Deuteranomaly/Protanomaly) and fails WCAG AA contrast ratios against white backgrounds.
 **Action:** Replaced the red/green paired colors with a higher-contrast, color-blind friendly scheme using red (`#d62728`) and blue (`#1f77b4`), applying it via `color_discrete_map` to consistently handle accessibility across charts.
+## 2024-10-18 - HTML Table Responsiveness and Interactive States
+**Learning:** Pandas DataFrame HTML tables generated directly in reports often break layouts on narrow mobile screens and lack clear visual distinction for reading and interactive elements.
+**Action:** Always wrap data tables in a `.table-responsive` container with `overflow-x: auto`. Additionally, ensure tables have zebra striping (`tr:nth-child(even)`) and hover states (`tr:hover`) for improved readability, and that hidden skip-to-content links utilize `:focus-visible` with high-contrast outlines (e.g., `#ff7f0e`) for robust keyboard navigation accessibility.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -559,6 +559,10 @@ class ExportUtils:
                     text-decoration: none;
                 }}
                 .skip-link:focus {{ top: 0; }}
+                .skip-link:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
+                .table-responsive {{ overflow-x: auto; }}
+                tr:nth-child(even) {{ background-color: #f9f9f9; }}
+                tr:hover {{ background-color: #f1f1f1; }}
             </style>
         </head>
         <body>
@@ -571,7 +575,9 @@ class ExportUtils:
 
                 <section aria-labelledby="summary-stats-title">
                     <h2 id="summary-stats-title">Summary Statistics</h2>
-                    {summary_df.to_html(index=False, classes='summary-table')}
+                    <div class="table-responsive">
+                        {summary_df.to_html(index=False, classes='summary-table')}
+                    </div>
                 </section>
 
                 <section aria-labelledby="data-overview-title">


### PR DESCRIPTION
### 💡 What:
Added a `.table-responsive` wrapper with horizontal scrolling around the Pandas DataFrame HTML output in `ivi_water/export_utils.py` and enhanced the CSS with table row striping and hover states.

### 🎯 Why:
Data-heavy Pandas HTML tables often overflow and break layouts on narrow mobile screens. Additionally, reading dense rows is difficult without visual aids like zebra striping or hover states.

### 📸 Before/After:
**Before:** HTML tables overflowed the screen on mobile, and rows lacked clear visual distinction.
**After:** Tables scroll horizontally on small screens (`overflow-x: auto`), and include light grey zebra striping and hover backgrounds for enhanced reading clarity.

### ♿ Accessibility:
Added a high-contrast `#ff7f0e` `focus-visible` outline to the visually hidden skip-to-content link, ensuring keyboard navigators can clearly see when they have focused on it.

---
*PR created automatically by Jules for task [17377362400271834629](https://jules.google.com/task/17377362400271834629) started by @dhruvhaldar*