### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to scrollable tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2024-10-18 - HTML Table Responsiveness and Interactive States
 **Learning:** Pandas DataFrame HTML tables generated directly in reports often break layouts on narrow mobile screens and lack clear visual distinction for reading and interactive elements.
 **Action:** Always wrap data tables in a `.table-responsive` container with `overflow-x: auto`. Additionally, ensure tables have zebra striping (`tr:nth-child(even)`) and hover states (`tr:hover`) for improved readability, and that hidden skip-to-content links utilize `:focus-visible` with high-contrast outlines (e.g., `#ff7f0e`) for robust keyboard navigation accessibility.
+## 2024-10-18 - Scrollable Container Keyboard Accessibility
+**Learning:** HTML elements with `overflow` (like `.table-responsive`) trap keyboard-only users who cannot scroll them horizontally because the container itself cannot receive focus.
+**Action:** Always add `tabindex="0"`, `role="region"`, and an `aria-labelledby` or `aria-label` attribute to scrollable containers, along with a `:focus-visible` outline for clear visual feedback.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -561,6 +561,7 @@ class ExportUtils:
                 .skip-link:focus {{ top: 0; }}
                 .skip-link:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 .table-responsive {{ overflow-x: auto; }}
+                .table-responsive:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 tr:nth-child(even) {{ background-color: #f9f9f9; }}
                 tr:hover {{ background-color: #f1f1f1; }}
             </style>
@@ -575,7 +576,7 @@ class ExportUtils:
 
                 <section aria-labelledby="summary-stats-title">
                     <h2 id="summary-stats-title">Summary Statistics</h2>
-                    <div class="table-responsive">
+                    <div class="table-responsive" tabindex="0" role="region" aria-labelledby="summary-stats-title">
                         {summary_df.to_html(index=False, classes='summary-table')}
                     </div>
                 </section>


### PR DESCRIPTION
**💡 What:**
Added keyboard navigation support to the `.table-responsive` horizontally scrolling tables in HTML reports. The container now has `tabindex="0"`, `role="region"`, and `aria-labelledby` attributes, and a `:focus-visible` CSS rule for visual feedback.

**🎯 Why:**
When a container has CSS `overflow-x: auto` (like the data tables in our HTML reports), users navigating only via a keyboard cannot scroll the contents because the container itself cannot receive focus. Adding these attributes allows keyboard-only users to focus the container and use arrow keys to view the entire table.

**📸 Before/After:**
*Before:* The table is scrollable by mouse/touch, but unreachable and unscrollable via the keyboard.
*After:* The table container receives focus via the `Tab` key, displays a high-contrast outline (`#ff7f0e`), and can be scrolled horizontally using arrow keys.

**♿ Accessibility:**
Improves keyboard accessibility for users relying on keyboard navigation. Ensures that screen readers can correctly identify the region using `role="region"` and `aria-labelledby`. Included a journal entry detailing this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [17892668116508434430](https://jules.google.com/task/17892668116508434430) started by @dhruvhaldar*