### PR TITLE
🎨 Palette: Add accessibility attributes to Plotly charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-10-18 - Scrollable Container Keyboard Accessibility
 **Learning:** HTML elements with `overflow` (like `.table-responsive`) trap keyboard-only users who cannot scroll them horizontally because the container itself cannot receive focus.
 **Action:** Always add `tabindex="0"`, `role="region"`, and an `aria-labelledby` or `aria-label` attribute to scrollable containers, along with a `:focus-visible` outline for clear visual feedback.
+## 2024-11-20 - Interactive Plotly Chart Accessibility
+**Learning:** Plotly interactive charts exported to HTML generate a container div (`<div class="plotly-graph-div">`) that lacks screen reader and keyboard accessibility attributes, leaving the visualization opaque and inaccessible to non-visual users navigating the document.
+**Action:** Always inject `role="region"`, a descriptive `aria-label`, and `tabindex="0"` into the `plotly-graph-div` container when generating standalone HTML or reports with Plotly. This allows screen readers to announce the interactive area and keyboard users to focus on it.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -861,6 +861,12 @@ For questions or support, contact: IVI Water Trends Team"""
                             '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
                         )
 
+                        # Add accessibility attributes to the graph container
+                        html_content = html_content.replace(
+                            'class="plotly-graph-div"',
+                            'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"'
+                        )
+
                         from .security_utils import inject_csp_meta_tag
 
                         html_content = inject_csp_meta_tag(html_content)

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -723,6 +723,12 @@ class WaterTrendsVisualizer:
                 '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
             )
 
+            # Add accessibility attributes to the graph container
+            html_content = html_content.replace(
+                'class="plotly-graph-div"',
+                'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"'
+            )
+
             # Inject CSP meta tag for security
             from .security_utils import inject_csp_meta_tag
 
@@ -829,6 +835,12 @@ class WaterTrendsVisualizer:
             html_content = html_content.replace(
                 "<head>",
                 '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
+            )
+
+            # Add accessibility attributes to the graph container
+            html_content = html_content.replace(
+                'class="plotly-graph-div"',
+                'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"'
             )
 
             # Inject CSP meta tag for security


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 **What:** Added accessibility attributes (`role="region"`, `aria-label`, and `tabindex="0"`) to the Plotly chart container `<div>` when exported to HTML.
🎯 **Why:** To ensure that interactive Plotly charts are focusable by keyboard-only users and properly announced to screen reader users instead of being an opaque element in the document.
📸 **Before/After:**
Before: `<div id="..." class="plotly-graph-div" style="..."></div>`
After: `<div id="..." class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0" style="..."></div>`
♿ **Accessibility:** This makes the Plotly interactive area a proper landmark region that can receive focus.

---
*PR created automatically by Jules for task [17121094523359837636](https://jules.google.com/task/17121094523359837636) started by @dhruvhaldar*