### PR TITLE
🎨 Palette: [UX improvement] Enhance Data Overview readability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2024-11-20 - Interactive Plotly Chart Accessibility
 **Learning:** Plotly interactive charts exported to HTML generate a container div (`<div class="plotly-graph-div">`) that lacks screen reader and keyboard accessibility attributes, leaving the visualization opaque and inaccessible to non-visual users navigating the document.
 **Action:** Always inject `role="region"`, a descriptive `aria-label`, and `tabindex="0"` into the `plotly-graph-div` container when generating standalone HTML or reports with Plotly. This allows screen readers to announce the interactive area and keyboard users to focus on it.
+## 2024-12-05 - Semantic Lists for Technical Data Readability
+**Learning:** Dumping pandas DataFrame columns as comma-separated strings in HTML reports creates a dense wall of text that is hostile to screen readers and difficult for users to visually scan.
+**Action:** Always format data schemas and column lists as semantic unordered lists (`<ul>`) with visual badge styling to improve scannability and structural navigation for assistive technologies.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -556,6 +556,7 @@ class ExportUtils:
 
         # Safe column names
         safe_columns = [html.escape(str(col)) for col in df.columns]
+        columns_html = '\n                        '.join(f'<li class="column-badge">{col}</li>' for col in safe_columns)
 
         # HTML content
         html_content = f"""
@@ -590,6 +591,9 @@ class ExportUtils:
                 .table-responsive:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 tr:nth-child(even) {{ background-color: #f9f9f9; }}
                 tr:hover {{ background-color: #f1f1f1; }}
+                .column-list {{ display: flex; flex-wrap: wrap; gap: 8px; padding: 0; list-style: none; margin-top: 15px; }}
+                .column-badge {{ background-color: #e2e8f0; color: #334155; padding: 4px 10px; border-radius: 16px; font-size: 0.9em; font-family: monospace; border: 1px solid #cbd5e1; }}
+                .visually-hidden {{ position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }}
             </style>
         </head>
         <body>
@@ -609,8 +613,11 @@ class ExportUtils:
 
                 <section aria-labelledby="data-overview-title">
                     <h2 id="data-overview-title">Data Overview</h2>
-                    <p>Total records: {len(df)}</p>
-                    <p>Columns: {', '.join(safe_columns)}</p>
+                    <p>Total records: <strong>{len(df):,}</strong></p>
+                    <h3 class="visually-hidden">Columns</h3>
+                    <ul class="column-list" aria-label="Dataset columns">
+                        {columns_html}
+                    </ul>
                 </section>
             </main>
         </body>


### PR DESCRIPTION
### 💡 What
Updated the "Data Overview" section of the HTML report generator to display the list of DataFrame columns as a semantic unordered list (`<ul>`) with visual badge styling, rather than a comma-separated paragraph. Additionally, formatted the "Total records" count with thousands separators (commas).

### 🎯 Why
Dumping a large number of DataFrame columns as a single comma-separated string creates a dense wall of text that is difficult for users to scan quickly. The thousands separator for the total record count ensures large numbers are easily legible.

### 📸 Before/After
**Before:**
```html
<p>Total records: 15430</p>
<p>Columns: location_id, year, season, water_area_ha, water_body_count, data_quality</p>
```

**After:**
```html
<p>Total records: <strong>15,430</strong></p>
<h3 class="visually-hidden">Columns</h3>
<ul class="column-list" aria-label="Dataset columns">
    <li class="column-badge">location_id</li>
    ...
</ul>
```

### ♿ Accessibility
- Replaced a visually dense paragraph with a semantic `<ul>` list, allowing screen reader users to easily navigate and enumerate the columns.
- Added a visually hidden heading and `aria-label` to provide proper context for the list.
- Improved visual scannability by using high-contrast badge styling (`.column-badge`) with clear spacing (`gap: 8px`), aiding users with cognitive or visual processing difficulties.

---
*PR created automatically by Jules for task [16845465851709830477](https://jules.google.com/task/16845465851709830477) started by @dhruvhaldar*