### PR TITLE
🎨 Palette: Add keyboard focus indicators to interactive Plotly charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-11-20 - Interactive Plotly Chart Accessibility
 **Learning:** Plotly interactive charts exported to HTML generate a container div (`<div class="plotly-graph-div">`) that lacks screen reader and keyboard accessibility attributes, leaving the visualization opaque and inaccessible to non-visual users navigating the document.
 **Action:** Always inject `role="region"`, a descriptive `aria-label`, and `tabindex="0"` into the `plotly-graph-div` container when generating standalone HTML or reports with Plotly. This allows screen readers to announce the interactive area and keyboard users to focus on it.
+
+## 2024-05-24 - Add Explicit Keyboard Focus to Plotly HTML Exports
+**Learning:** Plotly's interactive chart containers (`.plotly-graph-div`) receive keyboard focus when configured properly (e.g., via `tabindex="0"`), but their default HTML exports completely lack visual focus indicators. This means keyboard-only users have no way to see when they've tabbed onto the chart container.
+**Action:** When exporting Plotly charts to interactive HTML via `to_html()`, always inject custom `<style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>` into the document `<head>` to ensure proper WCAG focus visibility.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -884,7 +884,7 @@ For questions or support, contact: IVI Water Trends Team"""
                         # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
+                            '<head>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
                         )
 
                         # Add accessibility attributes to the graph container

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -720,7 +720,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
+                '<head>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
             )
 
             # Add accessibility attributes to the graph container
@@ -834,7 +834,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
+                '<head>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
             )
 
             # Add accessibility attributes to the graph container


### PR DESCRIPTION
### 💡 What
Added explicit `:focus-visible` CSS rules to the `<head>` of generated HTML files containing interactive Plotly charts.

### 🎯 Why
By default, Plotly interactive chart containers (`.plotly-graph-div`) receive keyboard focus when configured properly (e.g., via `tabindex="0"`), but their default HTML exports lack any visual focus indicators. Without this, keyboard-only users have no visual way to tell when they've tabbed onto the chart container.

### 📸 Before/After
**Before:** Tabbing onto a Plotly chart container results in no visual change, making it impossible to know where focus is.
**After:** Tabbing onto a Plotly chart container clearly outlines the interactive region with a high-contrast orange ring (`#ff7f0e`).

### ♿ Accessibility
- Dramatically improves keyboard navigation by satisfying WCAG 2.4.7 Focus Visible.
- Complements existing screen reader accessibility attributes (`role="region"`, `aria-label`, `tabindex="0"`) added in prior PRs.

---
*PR created automatically by Jules for task [11180521645316887411](https://jules.google.com/task/11180521645316887411) started by @dhruvhaldar*