### PR TITLE
🎨 Palette: [UX improvement] Add :focus-visible to interactive Plotly charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-11-20 - Interactive Plotly Chart Accessibility
 **Learning:** Plotly interactive charts exported to HTML generate a container div (`<div class="plotly-graph-div">`) that lacks screen reader and keyboard accessibility attributes, leaving the visualization opaque and inaccessible to non-visual users navigating the document.
 **Action:** Always inject `role="region"`, a descriptive `aria-label`, and `tabindex="0"` into the `plotly-graph-div` container when generating standalone HTML or reports with Plotly. This allows screen readers to announce the interactive area and keyboard users to focus on it.
+
+## 2024-04-03 - Focus Visible for Third-Party Components
+**Learning:** Injecting `tabindex="0"` into third-party component wrappers (like Plotly's HTML export) is not enough for keyboard accessibility. You must explicitly inject corresponding `:focus-visible` CSS as well, because the library's default styles will not cover custom accessibility enhancements. Without it, the focus indicator will not appear.
+**Action:** Always pair `tabindex="0"` additions with `:focus-visible` CSS rules when enhancing third-party component wrappers.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -884,7 +884,7 @@ For questions or support, contact: IVI Water Trends Team"""
                         # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
+                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
                         )
 
                         # Add accessibility attributes to the graph container

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -720,7 +720,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>',
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
             )
 
             # Add accessibility attributes to the graph container
@@ -834,7 +834,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>',
+                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
             )
 
             # Add accessibility attributes to the graph container


### PR DESCRIPTION
**What:** 
Added a `:focus-visible` CSS outline rule to the `.plotly-graph-div` containers when generating Plotly HTML exports.

**Why:** 
The interactive Plotly charts previously had `tabindex="0"` added for keyboard accessibility, but lacked any visual indicator to show when they actually received keyboard focus.

**Before/After:**
- **Before:** Keyboard users tabbing to the chart would see no visual change indicating they could interact with it.
- **After:** Keyboard users see a high-contrast orange (`#ff7f0e`) outline when the chart is focused, making it clear they can interact. Mouse clicks do not trigger the outline.

**Accessibility:**
- Ensures keyboard navigators can see their focus position.
- Fixes the gap where third-party libraries don't provide sufficient default accessibility styles.

---
*PR created automatically by Jules for task [4929277373896306467](https://jules.google.com/task/4929277373896306467) started by @dhruvhaldar*