### PR TITLE
🎨 Palette: Improve column list accessibility and readability in HTML report

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2024-11-20 - Interactive Plotly Chart Accessibility
 **Learning:** Plotly interactive charts exported to HTML generate a container div (`<div class="plotly-graph-div">`) that lacks screen reader and keyboard accessibility attributes, leaving the visualization opaque and inaccessible to non-visual users navigating the document.
 **Action:** Always inject `role="region"`, a descriptive `aria-label`, and `tabindex="0"` into the `plotly-graph-div` container when generating standalone HTML or reports with Plotly. This allows screen readers to announce the interactive area and keyboard users to focus on it.
+
+## 2024-04-04 - Semantic Lists over Comma-Separated Strings for Readability
+**Learning:** Displaying lists of data attributes (like dataframe column names) as plain comma-separated strings inside `<p>` tags makes scanning visually difficult for sighted users and less semantically clear for screen readers compared to structured lists.
+**Action:** Always prefer rendering collections of items as semantic unordered lists (`<ul>`) with list items (`<li>`). Styling the list items as distinct "badges" or "chips" further improves visual scannability and structure.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -590,6 +590,8 @@ class ExportUtils:
                 .table-responsive:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 tr:nth-child(even) {{ background-color: #f9f9f9; }}
                 tr:hover {{ background-color: #f1f1f1; }}
+                .column-list {{ list-style-type: none; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }}
+                .column-badge {{ background-color: #e9ecef; color: #495057; padding: 4px 8px; border-radius: 4px; font-size: 0.9em; border: 1px solid #ced4da; }}
             </style>
         </head>
         <body>
@@ -610,7 +612,10 @@ class ExportUtils:
                 <section aria-labelledby="data-overview-title">
                     <h2 id="data-overview-title">Data Overview</h2>
                     <p>Total records: {len(df)}</p>
-                    <p>Columns: {', '.join(safe_columns)}</p>
+                    <p>Columns:</p>
+                    <ul class="column-list">
+                        {''.join(f'<li class="column-badge">{col}</li>' for col in safe_columns)}
+                    </ul>
                 </section>
             </main>
         </body>


### PR DESCRIPTION
**What:**
Changed the way the DataFrame column list is displayed in the HTML summary report (`_create_html_report` in `ivi_water/export_utils.py`). It now uses a semantic unordered list (`<ul>`) styled as individual "badges" rather than a plain comma-separated string.

**Why:**
Displaying lists of data attributes (like column names) as plain comma-separated strings inside `<p>` tags makes scanning visually difficult for sighted users and less semantically clear for screen readers compared to structured lists.

**Before/After:**
*   **Before:** `<p>Columns: location_id, year, water_area_ha</p>` (plain comma-separated text)
*   **After:**
    ```html
    <p>Columns:</p>
    <ul class="column-list">
        <li class="column-badge">location_id</li>
        <li class="column-badge">year</li>
        <li class="column-badge">water_area_ha</li>
    </ul>
    ```
    This renders as distinct, slightly styled grey chips that are very easy to read.

**Accessibility:**
Replaced text string generation with standard semantic unordered list `<ul>` and list items `<li>`. This gives screen readers proper list context (e.g., "List of 3 items..."), rather than having to read a continuous run-on sentence separated by pauses.

---
*PR created automatically by Jules for task [16064929169060108385](https://jules.google.com/task/16064929169060108385) started by @dhruvhaldar*