### PR TITLE
⚡ Bolt: [performance improvement] Optimize categorical groupby by passing observed=True

### DIFF
--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -524,7 +524,7 @@ class ExportUtils:
         if "water_area_ha" in df.columns and "year" in df.columns:
             # Create trend chart
             fig, ax = plt.subplots(figsize=self.figure_size)
-            yearly_avg = df.groupby("year")["water_area_ha"].mean()
+            yearly_avg = df.groupby("year", observed=True)["water_area_ha"].mean()
             ax.plot(yearly_avg.index, yearly_avg.values, marker="o", linewidth=2)
             ax.set_title("Average Water Area Over Time")
             ax.set_xlabel("Year")
@@ -714,7 +714,7 @@ class ExportUtils:
 
         # Water area trends
         if "water_area_ha" in df.columns and "year" in df.columns:
-            yearly_avg = df.groupby("year")["water_area_ha"].mean()
+            yearly_avg = df.groupby("year", observed=True)["water_area_ha"].mean()
             if len(yearly_avg) > 1:
                 trend_slope = np.polyfit(yearly_avg.index, yearly_avg.values, 1)[0]
                 if trend_slope > 0.5:
@@ -726,7 +726,7 @@ class ExportUtils:
 
         # Seasonal patterns
         if "season" in df.columns and "water_area_ha" in df.columns:
-            seasonal_avg = df.groupby("season")["water_area_ha"].mean()
+            seasonal_avg = df.groupby("season", observed=True)["water_area_ha"].mean()
             max_season = seasonal_avg.idxmax()
             min_season = seasonal_avg.idxmin()
             insights.append(

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -233,7 +233,7 @@ class WaterTrendsVisualizer:
             else:
                 # Aggregate across all locations
                 df_filtered = (
-                    df.groupby(["year", "season"])["water_area_ha"].mean().reset_index()
+                    df.groupby(["year", "season"], observed=True)["water_area_ha"].mean().reset_index()
                 )
                 title = title or "Average Seasonal Water Trends - All Locations"
                 self.logger.debug(
@@ -379,7 +379,7 @@ class WaterTrendsVisualizer:
 
         # Calculate average water area by intervention and year
         avg_data = (
-            df.groupby(["year", intervention_col])["water_area_ha"].mean().reset_index()
+            df.groupby(["year", intervention_col], observed=True)["water_area_ha"].mean().reset_index()
         )
         avg_data[intervention_col] = avg_data[intervention_col].map(
             {0: "Without Intervention", 1: "With Intervention"}
@@ -475,7 +475,7 @@ class WaterTrendsVisualizer:
         """
         # Pivot data for heatmap
         heatmap_data = df.pivot_table(
-            index="location_id", columns="year", values=metric, aggfunc="mean"
+            index="location_id", columns="year", values=metric, aggfunc="mean", observed=True
         )
 
         safe_title = self._sanitize_text(
@@ -651,7 +651,7 @@ class WaterTrendsVisualizer:
         for location in location_ids[:3]:
             safe_location = self._sanitize_text(location)
             loc_data = df_filtered[df_filtered["location_id"] == location]
-            avg_counts = loc_data.groupby("year")["water_body_count"].mean()
+            avg_counts = loc_data.groupby("year", observed=True)["water_body_count"].mean()
 
             fig.add_trace(
                 go.Scatter(
@@ -667,7 +667,7 @@ class WaterTrendsVisualizer:
 
         # Plot 3: Yearly comparison
         yearly_avg = (
-            df_filtered.groupby(["year", "location_id"])["water_area_ha"]
+            df_filtered.groupby(["year", "location_id"], observed=True)["water_area_ha"]
             .mean()
             .reset_index()
         )


### PR DESCRIPTION
💡 **What**: Added `observed=True` to `groupby` and `pivot_table` calls in `ivi_water/visualizer.py` and `ivi_water/export_utils.py`.

🎯 **Why**: In Pandas, when grouping by categorical data, the default behavior (`observed=False` in older versions) computes statistics for all possible categories, creating a Cartesian product of groups even if those combinations don't exist in the actual data. Setting `observed=True` ensures Pandas only groups by categories that actually appear in the data. This prevents massive memory spikes and significantly improves computation speed. It also future-proofs the codebase, as `observed=True` becomes the default behavior in Pandas 3.0.

📊 **Impact**: Faster execution and significantly reduced memory usage when visualizing or exporting data containing categorical columns with high cardinality or many unobserved categories.

🔬 **Measurement**: This optimization was verified by running the existing test suite, which ensures that aggregations still return correct results. Memory and CPU profiling on large datasets with many missing category combinations will show the performance improvement.

---
*PR created automatically by Jules for task [6525731458312213233](https://jules.google.com/task/6525731458312213233) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements made to data aggregation patterns for enhanced readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->