### PR TITLE
🎨 Palette: [UX improvement] Style columns as badges in HTML reports

### DIFF
--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -590,6 +590,8 @@ class ExportUtils:
                 .table-responsive:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 tr:nth-child(even) {{ background-color: #f9f9f9; }}
                 tr:hover {{ background-color: #f1f1f1; }}
+                .badge-list {{ list-style-type: none; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; margin: 0; }}
+                .badge {{ background-color: #e9ecef; color: #495057; padding: 4px 8px; border-radius: 4px; font-size: 0.9em; }}
             </style>
         </head>
         <body>
@@ -610,7 +612,10 @@ class ExportUtils:
                 <section aria-labelledby="data-overview-title">
                     <h2 id="data-overview-title">Data Overview</h2>
                     <p>Total records: {len(df)}</p>
-                    <p>Columns: {', '.join(safe_columns)}</p>
+                    <p id="columns-label" style="margin-bottom: 8px;">Columns:</p>
+                    <ul class="badge-list" aria-labelledby="columns-label">
+                        {''.join(f'<li class="badge">{col}</li>' for col in safe_columns)}
+                    </ul>
                 </section>
             </main>
         </body>


### PR DESCRIPTION
💡 What: Updated the HTML report generator to display DataFrame columns as a styled list of badges rather than a comma-separated string.
🎯 Why: A comma-separated list of columns is difficult to parse visually when there are many columns, and it is harder for screen readers to navigate. Badges provide distinct, skimmable elements.
📸 Before/After: Before, it was `<p>Columns: location_id, year, season</p>`. Now, it uses an unordered list with flex wrap styling and badge styling.
♿ Accessibility: Improved semantic HTML by using an unordered list (`<ul>`) and list items (`<li>`) for the columns, which allows screen readers to announce the number of items and navigate them individually. Added `aria-labelledby` to connect the list to its label.

---
*PR created automatically by Jules for task [7450795124703411248](https://jules.google.com/task/7450795124703411248) started by @dhruvhaldar*