### PR TITLE
🎨 Palette: [UX improvement] Add dynamic ARIA labels to interactive charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2024-04-03 - Focus Visible for Third-Party Components
 **Learning:** Injecting `tabindex="0"` into third-party component wrappers (like Plotly's HTML export) is not enough for keyboard accessibility. You must explicitly inject corresponding `:focus-visible` CSS as well, because the library's default styles will not cover custom accessibility enhancements. Without it, the focus indicator will not appear.
 **Action:** Always pair `tabindex="0"` additions with `:focus-visible` CSS rules when enhancing third-party component wrappers.
+
+## 2026-04-07 - Dynamic ARIA Labels for Plotly Charts
+**Learning:** Hardcoding generic ARIA labels like `aria-label="Interactive Chart"` across all visualizations creates a confusing experience for screen reader users when multiple charts exist on the same page. Without specific context, users cannot distinguish between different data representations.
+**Action:** Always extract the dynamic, specific title (e.g., `fig.layout.title.text`), strip any embedded HTML tags, HTML-escape it for safety, and use it in the `aria-label` attribute when injecting accessibility metadata into third-party wrapper elements.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -891,10 +891,22 @@ For questions or support, contact: IVI Water Trends Team"""
                             '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
                         )
 
-                        # Add accessibility attributes to the graph container
+                        # Add accessibility attributes to the graph container with dynamic ARIA label
+                        title_text = "Interactive Water Trends Chart"
+                        if getattr(fig.layout, "title", None) and getattr(
+                            fig.layout.title, "text", None
+                        ):
+                            import re, html as html_lib
+
+                            # Extract text, remove HTML tags, and escape for attribute safety
+                            raw_text = html_lib.unescape(fig.layout.title.text)
+                            clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
+                            if clean_text:
+                                title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+
                         html_content = html_content.replace(
                             'class="plotly-graph-div"',
-                            'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"',
+                            f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
                         )
 
                         from .security_utils import inject_csp_meta_tag

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -231,7 +231,9 @@ class WaterTrendsVisualizer:
             else:
                 # Aggregate across all locations
                 df_filtered = (
-                    df.groupby(["year", "season"], observed=True)["water_area_ha"].mean().reset_index()
+                    df.groupby(["year", "season"], observed=True)["water_area_ha"]
+                    .mean()
+                    .reset_index()
                 )
                 title = title or "Average Seasonal Water Trends - All Locations"
                 self.logger.debug(
@@ -377,7 +379,9 @@ class WaterTrendsVisualizer:
 
         # Calculate average water area by intervention and year
         avg_data = (
-            df.groupby(["year", intervention_col], observed=True)["water_area_ha"].mean().reset_index()
+            df.groupby(["year", intervention_col], observed=True)["water_area_ha"]
+            .mean()
+            .reset_index()
         )
         avg_data[intervention_col] = avg_data[intervention_col].map(
             {0: "Without Intervention", 1: "With Intervention"}
@@ -473,7 +477,11 @@ class WaterTrendsVisualizer:
         """
         # Pivot data for heatmap
         heatmap_data = df.pivot_table(
-            index="location_id", columns="year", values=metric, aggfunc="mean", observed=True
+            index="location_id",
+            columns="year",
+            values=metric,
+            aggfunc="mean",
+            observed=True,
         )
 
         safe_title = self._sanitize_text(
@@ -649,7 +657,9 @@ class WaterTrendsVisualizer:
         for location in location_ids[:3]:
             safe_location = self._sanitize_text(location)
             loc_data = df_filtered[df_filtered["location_id"] == location]
-            avg_counts = loc_data.groupby("year", observed=True)["water_body_count"].mean()
+            avg_counts = loc_data.groupby("year", observed=True)[
+                "water_body_count"
+            ].mean()
 
             fig.add_trace(
                 go.Scatter(
@@ -721,10 +731,24 @@ class WaterTrendsVisualizer:
                 '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
             )
 
-            # Add accessibility attributes to the graph container
+            # Add accessibility attributes to the graph container with dynamic ARIA label
+            title_text = "Interactive Water Trends Chart"
+            if getattr(fig.layout, "title", None) and getattr(
+                fig.layout.title, "text", None
+            ):
+                import re, html as html_lib
+
+                # Extract text, remove HTML tags, and escape for attribute safety
+                raw_text = html_lib.unescape(fig.layout.title.text)
+                clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
+                if clean_text:
+                    title_text = (
+                        f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+                    )
+
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
-                'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"',
+                f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
             )
 
             # Inject CSP meta tag for security
@@ -835,10 +859,24 @@ class WaterTrendsVisualizer:
                 '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
             )
 
-            # Add accessibility attributes to the graph container
+            # Add accessibility attributes to the graph container with dynamic ARIA label
+            title_text = "Interactive Water Trends Chart"
+            if getattr(fig.layout, "title", None) and getattr(
+                fig.layout.title, "text", None
+            ):
+                import re, html as html_lib
+
+                # Extract text, remove HTML tags, and escape for attribute safety
+                raw_text = html_lib.unescape(fig.layout.title.text)
+                clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
+                if clean_text:
+                    title_text = (
+                        f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+                    )
+
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
-                'class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0"',
+                f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
             )
 
             # Inject CSP meta tag for security


### PR DESCRIPTION
### 💡 What
Replaced the hardcoded, generic `aria-label="Interactive Water Trends Chart"` on Plotly's exported HTML `.plotly-graph-div` containers with dynamic titles extracted from the actual chart titles (e.g., `fig.layout.title.text`). Safely strips any HTML tags and escapes the string for attribute safety.

### 🎯 Why
When exporting dashboards or multiple plots to HTML, having the exact same generic `aria-label` for every chart provides no context to screen-reader users, making it impossible to distinguish between different visualizations before interacting with them.

### 📸 Before/After
**Before:** All charts had the same aria label: `<div class="plotly-graph-div" role="region" aria-label="Interactive Water Trends Chart" tabindex="0">`
**After:** Charts are now distinct: `<div class="plotly-graph-div" role="region" aria-label="Water Area Trends by Season - Interactive Chart" tabindex="0">`

### ♿ Accessibility
This change ensures that keyboard and screen-reader users can uniquely identify and understand the context of different visualizations before navigating into their interactive regions.

---
*PR created automatically by Jules for task [12222787004793195056](https://jules.google.com/task/12222787004793195056) started by @dhruvhaldar*