### PR TITLE
🎨 Palette: [UX improvement] Add thousands separators for readability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-04-07 - Dynamic ARIA Labels for Plotly Charts
 **Learning:** Hardcoding generic ARIA labels like `aria-label="Interactive Chart"` across all visualizations creates a confusing experience for screen reader users when multiple charts exist on the same page. Without specific context, users cannot distinguish between different data representations.
 **Action:** Always extract the dynamic, specific title (e.g., `fig.layout.title.text`), strip any embedded HTML tags, HTML-escape it for safety, and use it in the `aria-label` attribute when injecting accessibility metadata into third-party wrapper elements.
+
+## 2024-10-24 - Number Formatting for Readability
+**Learning:** Raw integers displayed in summary tables and data reports (e.g., `1234567`) are difficult for users to parse at a glance and increase cognitive load compared to properly formatted numbers.
+**Action:** Always apply thousands separators (e.g., via f-string formatting like `f"{value:,}"`) to large numerical values in data tables, summaries, and HTML text output to improve quick scanning and readability.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -396,13 +396,15 @@ class ExportUtils:
         summary_data = []
 
         # Basic statistics
-        summary_data.append(["Total Records", len(df)])
-        summary_data.append(
-            [
-                "Unique Locations",
-                df["location_id"].nunique() if "location_id" in df.columns else "N/A",
-            ]
+        summary_data.append(["Total Records", f"{len(df):,}"])
+
+        unique_locs = (
+            df["location_id"].nunique() if "location_id" in df.columns else "N/A"
         )
+        if isinstance(unique_locs, (int, float)):
+            unique_locs = f"{unique_locs:,}"
+        summary_data.append(["Unique Locations", unique_locs])
+
         summary_data.append(
             [
                 "Year Range",
@@ -417,20 +419,20 @@ class ExportUtils:
         # Water statistics
         if "water_area_ha" in df.columns:
             summary_data.append(
-                ["Mean Water Area (ha)", f"{df['water_area_ha'].mean():.2f}"]
+                ["Mean Water Area (ha)", f"{df['water_area_ha'].mean():,.2f}"]
             )
             summary_data.append(
-                ["Max Water Area (ha)", f"{df['water_area_ha'].max():.2f}"]
+                ["Max Water Area (ha)", f"{df['water_area_ha'].max():,.2f}"]
             )
             summary_data.append(
-                ["Min Water Area (ha)", f"{df['water_area_ha'].min():.2f}"]
+                ["Min Water Area (ha)", f"{df['water_area_ha'].min():,.2f}"]
             )
 
         # Intervention statistics
         if "pond_presence" in df.columns:
             with_pond = df[df["pond_presence"] == 1].shape[0]
-            summary_data.append(["Records with Pond", with_pond])
-            summary_data.append(["Records without Pond", len(df) - with_pond])
+            summary_data.append(["Records with Pond", f"{with_pond:,}"])
+            summary_data.append(["Records without Pond", f"{len(df) - with_pond:,}"])
 
         return pd.DataFrame(summary_data, columns=["Metric", "Value"])
 
@@ -610,7 +612,7 @@ class ExportUtils:
 
                 <section aria-labelledby="data-overview-title">
                     <h2 id="data-overview-title">Data Overview</h2>
-                    <p>Total records: {len(df)}</p>
+                    <p>Total records: {len(df):,}</p>
                     <p id="columns-label" style="margin-bottom: 8px;">Columns:</p>
                     <ul class="badge-list" aria-labelledby="columns-label">
                         {''.join(f'<li class="badge">{col}</li>' for col in safe_columns)}


### PR DESCRIPTION
**💡 What:**
Added thousands separators (commas) to large numerical values displayed in summary data tables and HTML report views (e.g., changing `123456` to `123,456`).

**🎯 Why:**
Raw, unformatted integers are difficult to parse visually at a glance. By adding thousands separators, the cognitive load required to read large values in data reports is significantly reduced, making the interface more pleasant and scannable.

**📸 Before/After:**
*Before:* `Total Records: 1234567`
*After:* `Total Records: 1,234,567`

**♿ Accessibility:**
Improves general cognitive accessibility by making numerical data easier to process.

---
*PR created automatically by Jules for task [5663168648122613285](https://jules.google.com/task/5663168648122613285) started by @dhruvhaldar*