### PR TITLE
🎨 Palette: [UX improvement] Add thousands separators for readability

### DIFF
--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -666,25 +666,29 @@ class ExportUtils:
 
         # Format for Short (emoji-friendly, concise)
         water_area_avg = (
-            f"{df['water_area_ha'].mean():.1f} ha"
+            f"{df['water_area_ha'].mean():,.1f} ha"
             if "water_area_ha" in df.columns
             else "N/A"
         )
         water_area_max = (
-            f"{df['water_area_ha'].max():.1f} ha"
+            f"{df['water_area_ha'].max():,.1f} ha"
             if "water_area_ha" in df.columns
             else "N/A"
         )
 
         ponds_with = (
-            df[df["pond_presence"] == 1]["location_id"].nunique()
+            f"{df[df['pond_presence'] == 1]['location_id'].nunique():,}"
             if "pond_presence" in df.columns
             else "N/A"
         )
         ponds_without = (
-            df[df["pond_presence"] == 0]["location_id"].nunique()
+            f"{df[df['pond_presence'] == 0]['location_id'].nunique():,}"
             if "pond_presence" in df.columns
             else "N/A"
+        )
+
+        total_locations = (
+            f"{df['location_id'].nunique():,}" if "location_id" in df.columns else "N/A"
         )
 
         summary_text = f"""📊 *Water Trends Summary Report*
@@ -694,7 +698,7 @@ class ExportUtils:
 {insights}
 
 📈 *Quick Stats:*
-• Total Locations: {df['location_id'].nunique() if 'location_id' in df.columns else 'N/A'}
+• Total Locations: {total_locations}
 • Year Range: {df['year'].min()}-{df['year'].max() if 'year' in df.columns else 'N/A'}
 • Total Records: {len(df):,}
 

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -290,7 +290,7 @@ class WaterTrendsVisualizer:
                         fill="tonexty",
                         hovertemplate=f"<b>{season.capitalize()}</b><br>"
                         + "Year: %{x}<br>"
-                        + "Water Area: %{y:.2f} ha<extra></extra>",
+                        + "Water Area: %{y:,.2f} ha<extra></extra>",
                     )
                 )
 


### PR DESCRIPTION
💡 **What:** Added thousands separators to large numerical values in the `generate_short_summary` text report (water areas, location counts) and the Plotly `hovertemplate` (water area) in `visualizer.py`.

🎯 **Why:** Raw numbers like `12345.6` or `1234567` are difficult for users to parse quickly at a glance. Adding commas (e.g., `12,345.6`) significantly reduces cognitive load and improves readability of key metrics in generated text summaries and interactive chart tooltips.

📸 **Before/After:**
*   **Before:** `Avg Water Area: 1234.5 ha` | `Water Area: 1234.50 ha` (tooltip)
*   **After:** `Avg Water Area: 1,234.5 ha` | `Water Area: 1,234.50 ha` (tooltip)

♿ **Accessibility:** Formatting numbers natively in HTML tables and strings prevents screen readers from sometimes pronouncing strings of digits as a single uninterpretable number sequence or individual letters, depending on configuration.

---
*PR created automatically by Jules for task [13970325022919959222](https://jules.google.com/task/13970325022919959222) started by @dhruvhaldar*