### PR TITLE
🎨 Palette: [UX improvement] Consistent seasonal color mapping

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,6 @@
 ## 2024-10-24 - Number Formatting for Readability
 **Learning:** Raw integers displayed in summary tables and data reports (e.g., `1234567`) are difficult for users to parse at a glance and increase cognitive load compared to properly formatted numbers.
 **Action:** Always apply thousands separators (e.g., via f-string formatting like `f"{value:,}"`) to large numerical values in data tables, summaries, and HTML text output to improve quick scanning and readability.
+## 2024-05-24 - Consistent Semantic Color Mapping Across Dashboards
+**Learning:** When generating multiple visualizations that share a categorical dimension (e.g., seasons), omitting explicit color mapping (like `color_discrete_map`) in some charts causes plotting libraries to assign default palette colors. This inconsistency creates significant cognitive friction for users, as the same color means different things in different contexts.
+**Action:** Always apply explicit semantic color mappings (`color_discrete_map`) and category ordering (`category_orders`) consistently across all charts within an application or report.

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -447,6 +447,8 @@ class WaterTrendsVisualizer:
             labels={"water_body_count": "Number of Water Bodies", "count": "Frequency"},
             nbins=30,
             barmode="overlay",
+            color_discrete_map=SEASON_COLORS,
+            category_orders={"season": SEASON_ORDER},
         )
 
         fig.update_layout(
@@ -535,6 +537,8 @@ class WaterTrendsVisualizer:
             title=safe_title,
             labels={"water_area_ha": "Water Area (hectares)", "season": "Season"},
             color="season",
+            color_discrete_map=SEASON_COLORS,
+            category_orders={"season": SEASON_ORDER},
         )
 
         fig.update_layout(height=self.height, width=self.width, showlegend=False)


### PR DESCRIPTION
### What
Applied consistent semantic color mappings (`color_discrete_map`) and category ordering (`category_orders`) to the `create_water_body_distribution` and `create_seasonal_box_plot` functions in `ivi_water/visualizer.py`.

### Why
When generating multiple visualizations that share a categorical dimension (e.g., seasons), omitting explicit color mapping in some charts causes plotting libraries to assign default palette colors. This inconsistency creates significant cognitive friction for users, as the same color means different things in different contexts across the application's reporting dashboards.

### Before/After
**Before:** The `create_seasonal_stacked_area_chart` used explicit semantic colors (e.g., `#1f77b4` for perennial), but histograms and box plots used Plotly Express default cycling colors (e.g., `#636efa`).
**After:** All seasonal charts explicitly map to the predefined `SEASON_COLORS` and follow the `SEASON_ORDER`.

### Accessibility
This aligns the application more tightly with WCAG guidelines on using color systematically. The chosen predefined palette ensures robust contrast (as already established by the codebase's accessibility guidelines).

---
*PR created automatically by Jules for task [21989746035728720](https://jules.google.com/task/21989746035728720) started by @dhruvhaldar*