### PR TITLE
🎨 Palette: [UX improvement] Improve Plotly Tooltip Number Formatting

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,6 @@
 ## 2024-05-24 - Consistent Semantic Color Mapping Across Dashboards
 **Learning:** When generating multiple visualizations that share a categorical dimension (e.g., seasons), omitting explicit color mapping (like `color_discrete_map`) in some charts causes plotting libraries to assign default palette colors. This inconsistency creates significant cognitive friction for users, as the same color means different things in different contexts.
 **Action:** Always apply explicit semantic color mappings (`color_discrete_map`) and category ordering (`category_orders`) consistently across all charts within an application or report.
+## 2024-11-20 - Plotly Tooltip Formatting for Readability
+**Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
+**Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -644,6 +644,7 @@ class WaterTrendsVisualizer:
 
             for season in ["perennial", "winter", "monsoon"]:
                 if season in pivot_data.columns:
+                    color = SEASON_COLORS.get(season, "#7f7f7f")
                     fig.add_trace(
                         go.Scatter(
                             x=pivot_data.index,
@@ -651,7 +652,13 @@ class WaterTrendsVisualizer:
                             mode="lines",
                             stackgroup="one",
                             name=f"{safe_location} - {season}",
+                            line=dict(color=color, width=2),
+                            fillcolor=color,
+                            fill="tonexty",
                             showlegend=False,
+                            hovertemplate=f"<b>{safe_location} - {season.capitalize()}</b><br>"
+                            + "Year: %{x}<br>"
+                            + "Water Area: %{y:,.2f} ha<extra></extra>",
                         ),
                         row=1,
                         col=1,
@@ -672,6 +679,9 @@ class WaterTrendsVisualizer:
                     mode="lines+markers",
                     name=f"{safe_location} - Bodies",
                     showlegend=False,
+                    hovertemplate=f"<b>{safe_location}</b><br>"
+                    + "Year: %{x}<br>"
+                    + "Avg Bodies: %{y:,.2f}<extra></extra>",
                 ),
                 row=1,
                 col=2,
@@ -694,6 +704,9 @@ class WaterTrendsVisualizer:
                     mode="lines+markers",
                     name=safe_location,
                     showlegend=False,
+                    hovertemplate=f"<b>{safe_location}</b><br>"
+                    + "Year: %{x}<br>"
+                    + "Water Area: %{y:,.2f} ha<extra></extra>",
                 ),
                 row=2,
                 col=1,
@@ -706,6 +719,9 @@ class WaterTrendsVisualizer:
                 nbinsx=30,
                 name="Distribution",
                 showlegend=False,
+                hovertemplate="<b>Distribution</b><br>"
+                + "Area: %{x:,.2f} ha<br>"
+                + "Count: %{y:,}<extra></extra>",
             ),
             row=2,
             col=2,


### PR DESCRIPTION
### 💡 What
Updated the `create_multi_location_dashboard` interactive tooltips to use Plotly's `hovertemplate` functionality with d3-style formatting. This injects thousands separators (e.g., `%{y:,.2f}`) into the large values (like water area in hectares) displayed upon hover, and additionally applies semantic color mapping to the seasonal charts for consistency. I also recorded this learning into `.Jules/palette.md`.

### 🎯 Why
Raw integer and floating-point values are difficult to quickly parse, increasing cognitive load for users exploring the dashboard. Properly formatted numbers directly improve the scanning and readability experience of the interactive data visualizations, making them more aligned with the static reports. Applying semantic colors across charts ensures a consistent visual experience so users don't misinterpret data mapped to default alternating colors.

### 📸 Before/After
*Before:* Hovering over points showed raw, unformatted numbers without commas (e.g., `45231.55`) in standard boxes.
*After:* Hover tooltips now display nicely formatted, bolded labels with thousands separators (e.g., `45,231.55 ha`).

### ♿ Accessibility
Improved information parsing speed and reduced cognitive load for users consuming the interactive data. Consistent color mapping ensures standard contrast ratios (like colorblind-friendly red/blue maps) apply safely to complex combined dashboards.

---
*PR created automatically by Jules for task [2512514848052598951](https://jules.google.com/task/2512514848052598951) started by @dhruvhaldar*