### PR TITLE
🎨 Palette: [UX improvement] Fix skip-link focus management

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,6 @@
 ## 2024-11-20 - Plotly Tooltip Formatting for Readability
 **Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
 **Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.
+## 2026-04-13 - Skip-Link Target Focus Management
+**Learning:** When using skip-to-content links that target non-interactive elements (like an `<h2>` heading), keyboard focus might not visually transfer in some browsers, or conversely, it may show an ugly default focus ring when the element receives programmatic focus.
+**Action:** Always add `tabindex="-1"` to the skip link's target element so it can programmatically receive focus, and apply CSS (e.g., `[tabindex="-1"]:focus { outline: none; }`) to remove the default focus outline, ensuring a smooth, visually clean transition.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -588,6 +588,7 @@ class ExportUtils:
                 }}
                 .skip-link:focus {{ top: 0; }}
                 .skip-link:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
+                h2[tabindex="-1"]:focus {{ outline: none; }}
                 .table-responsive {{ overflow-x: auto; }}
                 .table-responsive:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
                 tr:nth-child(even) {{ background-color: #f9f9f9; }}
@@ -605,7 +606,7 @@ class ExportUtils:
                 </header>
 
                 <section aria-labelledby="summary-stats-title">
-                    <h2 id="summary-stats-title">Summary Statistics</h2>
+                    <h2 id="summary-stats-title" tabindex="-1">Summary Statistics</h2>
                     <div class="table-responsive" tabindex="0" role="region" aria-labelledby="summary-stats-title">
                         {summary_df.to_html(index=False, classes='summary-table')}
                     </div>


### PR DESCRIPTION
### 💡 What
Added `tabindex="-1"` to the `#summary-stats-title` heading (the target of the skip-to-content link) in the generated HTML report and provided custom CSS (`h2[tabindex="-1"]:focus { outline: none; }`) to remove the default focus ring. Also updated the `.Jules/palette.md` journal.

### 🎯 Why
When a skip link targets a non-interactive element like an `<h2>`, adding `tabindex="-1"` ensures that the element can programmatically receive focus, which fixes behavior in some browsers that don't reliably transfer focus otherwise. However, this programmatic focus can cause the browser to render an ugly default outline around the heading. This change manages the focus invisibly for a better user experience.

### ♿ Accessibility
- Ensures keyboard focus is properly managed and transferred when the skip link is used.
- Prevents visual confusion for sighted keyboard users by hiding the focus outline on the non-interactive header target.

---
*PR created automatically by Jules for task [9627602909828518186](https://jules.google.com/task/9627602909828518186) started by @dhruvhaldar*