### PR TITLE
🎨 Palette: [UX improvement] Add thousands separators to chart tooltips and axes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,6 @@
 ## 2026-04-13 - Skip-Link Target Focus Management
 **Learning:** When using skip-to-content links that target non-interactive elements (like an `<h2>` heading), keyboard focus might not visually transfer in some browsers, or conversely, it may show an ugly default focus ring when the element receives programmatic focus.
 **Action:** Always add `tabindex="-1"` to the skip link's target element so it can programmatically receive focus, and apply CSS (e.g., `[tabindex="-1"]:focus { outline: none; }`) to remove the default focus outline, ensuring a smooth, visually clean transition.
+## 2024-11-20 - Chart Tooltip Readability
+**Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
+**Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -411,6 +411,12 @@ class WaterTrendsVisualizer:
 
         fig.update_layout(height=self.height, width=self.width, hovermode="x unified")
 
+        fig.update_traces(
+            hovertemplate="<b>%{data.name}</b><br>Year: %{x}<br>"
+            "Average Water Area: %{y:,.2f} ha<extra></extra>"
+        )
+        fig.update_yaxes(tickformat=",.2f")
+
         return fig
 
     def create_water_body_distribution(
@@ -458,6 +464,12 @@ class WaterTrendsVisualizer:
             yaxis_title="Frequency",
         )
 
+        fig.update_traces(
+            hovertemplate="<b>%{data.name}</b><br>Number of Water Bodies: %{x}<br>"
+            "Frequency: %{y:,}<extra></extra>"
+        )
+        fig.update_yaxes(tickformat=",")
+
         return fig
 
     def create_trend_heatmap(
@@ -501,6 +513,11 @@ class WaterTrendsVisualizer:
             height=max(self.height, len(heatmap_data) * 20), width=self.width
         )
 
+        fig.update_traces(
+            hovertemplate="Location: %{y}<br>Year: %{x}<br>"
+            "Value: %{z:,.2f}<extra></extra>"
+        )
+
         return fig
 
     def create_seasonal_box_plot(
@@ -542,6 +559,12 @@ class WaterTrendsVisualizer:
         )
 
         fig.update_layout(height=self.height, width=self.width, showlegend=False)
+
+        fig.update_traces(
+            hovertemplate="<b>%{data.name}</b><br>"
+            "Water Area: %{y:,.2f} ha<extra></extra>"
+        )
+        fig.update_yaxes(tickformat=",.2f")
 
         return fig
 
@@ -598,6 +621,14 @@ class WaterTrendsVisualizer:
         )
 
         fig.update_layout(height=self.height, width=self.width)
+
+        # Ensure dynamic tooltip formatting based on axes values
+        fig.update_traces(
+            hovertemplate="<b>%{data.name}</b><br>"
+            "Water Area: %{x:,.2f} ha<br>Impact: %{y:,.2f}<extra></extra>"
+        )
+        fig.update_xaxes(tickformat=",.2f")
+        fig.update_yaxes(tickformat=",.2f")
 
         return fig
 


### PR DESCRIPTION
💡 What: Formatted numbers with thousands separators in Plotly Express chart axes and tooltips.
🎯 Why: Raw numbers (like 1234567.89) are difficult to parse quickly. Adding thousands separators improves readability and cognitive load.
📸 Before/After: Visual change in tooltips and axes on line, scatter, box, and histogram plots.
♿ Accessibility: Easier to read for users with cognitive or visual processing challenges.

---
*PR created automatically by Jules for task [10268320514747747977](https://jules.google.com/task/10268320514747747977) started by @dhruvhaldar*