### PR TITLE
🎨 Palette: Dynamic `<title>` tags for HTML exports

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,6 @@
 ## 2024-11-20 - Chart Tooltip Readability
 **Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
 **Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.
+## 2024-11-20 - Dynamic Page Titles for Exported Interactive Charts
+**Learning:** Hardcoding generic `<title>` tags (e.g., `<title>Water Trends Visualization</title>`) for exported Plotly HTML files creates a poor experience for screen reader users when navigating multiple tabs, violating WCAG 2.4.2 (Page Titled). Without a specific, descriptive title, users cannot distinguish between different charts or dashboards loaded in their browser.
+**Action:** When exporting interactive Plotly charts or dashboards to HTML (e.g., via `to_html()`), always extract the specific chart title (e.g., from `fig.layout.title.text`), sanitize it (escaping HTML and quotes), and dynamically inject it into the `<title>` tag in the HTML `<head>`.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -893,14 +893,9 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
-                        # Add title and viewport for accessibility and mobile responsiveness
-                        html_content = html_content.replace(
-                            "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-                        )
-
-                        # Add accessibility attributes to the graph container with dynamic ARIA label
-                        title_text = "Interactive Water Trends Chart"
+                        # Extract title for accessibility attributes and <title> tag
+                        page_title = "Water Trends Visualization"
+                        aria_label = "Interactive Water Trends Chart"
                         if getattr(fig.layout, "title", None) and getattr(
                             fig.layout.title, "text", None
                         ):
@@ -910,11 +905,18 @@ For questions or support, contact: IVI Water Trends Team"""
                             raw_text = html_lib.unescape(fig.layout.title.text)
                             clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
                             if clean_text:
-                                title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+                                page_title = html_lib.escape(clean_text)
+                                aria_label = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+
+                        # Add title and viewport for accessibility and mobile responsiveness
+                        html_content = html_content.replace(
+                            "<head>",
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{page_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                        )
 
                         html_content = html_content.replace(
                             'class="plotly-graph-div"',
-                            f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
+                            f'class="plotly-graph-div" role="region" aria-label="{aria_label}" tabindex="0"',
                         )
 
                         from .security_utils import inject_csp_meta_tag

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -776,14 +776,9 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
-            title_text = "Interactive Water Trends Chart"
+            # Extract title for accessibility attributes and <title> tag
+            page_title = "Water Trends Dashboard"
+            aria_label = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
@@ -793,13 +788,20 @@ class WaterTrendsVisualizer:
                 raw_text = html_lib.unescape(fig.layout.title.text)
                 clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
                 if clean_text:
-                    title_text = (
+                    page_title = html_lib.escape(clean_text)
+                    aria_label = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
 
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{page_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
-                f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
+                f'class="plotly-graph-div" role="region" aria-label="{aria_label}" tabindex="0"',
             )
 
             # Inject CSP meta tag for security
@@ -904,14 +906,9 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
-            title_text = "Interactive Water Trends Chart"
+            # Extract title for accessibility attributes and <title> tag
+            page_title = "Water Trends Visualization"
+            aria_label = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
@@ -921,13 +918,20 @@ class WaterTrendsVisualizer:
                 raw_text = html_lib.unescape(fig.layout.title.text)
                 clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
                 if clean_text:
-                    title_text = (
+                    page_title = html_lib.escape(clean_text)
+                    aria_label = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
 
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{page_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
-                f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
+                f'class="plotly-graph-div" role="region" aria-label="{aria_label}" tabindex="0"',
             )
 
             # Inject CSP meta tag for security


### PR DESCRIPTION
### 💡 What:
Replaced hardcoded, generic `<title>` tags (like "Water Trends Visualization") with specific, dynamically extracted titles from the Plotly figures when exporting interactive HTML charts/dashboards.

### 🎯 Why:
To solve an accessibility problem where screen reader users could not distinguish between different exported charts when navigating multiple browser tabs, as they all shared the same generic page title. 

### 📸 Before/After:
**Before:** `<title>Water Trends Visualization</title>`
**After:** `<title>Water Body Distribution (Winter) - Interactive Chart</title>`

### ♿ Accessibility:
This change directly addresses a WCAG 2.4.2 (Page Titled) violation. Specific page titles allow screen reader users to quickly orient themselves and understand the content of the document without having to navigate into the page content itself.

---
*PR created automatically by Jules for task [15255434495657447956](https://jules.google.com/task/15255434495657447956) started by @dhruvhaldar*