### PR TITLE
🎨 Palette: [UX improvement] Dynamic HTML titles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,7 @@
 ## 2024-11-20 - Chart Tooltip Readability
 **Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
 **Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.
+
+## 2026-04-18 - Dynamic HTML Titles for Screen Readers
+**Learning:** Hardcoding generic <title> tags in exported HTML dashboards and visualizations creates a poor experience for screen reader users, as it prevents clear tab identification and navigation when multiple visualizations are opened (violating WCAG 2.4.2).
+**Action:** Extract the specific chart title dynamically (e.g., from fig.layout.title.text), escape HTML tags, and inject it into the <title> tag of HTML exports instead of using a static fallback.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -893,14 +893,9 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
-                        # Add title and viewport for accessibility and mobile responsiveness
-                        html_content = html_content.replace(
-                            "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-                        )
-
-                        # Add accessibility attributes to the graph container with dynamic ARIA label
+                        # Extract title for accessibility attributes and <title> tag
                         title_text = "Interactive Water Trends Chart"
+                        doc_title = "Water Trends Visualization"
                         if getattr(fig.layout, "title", None) and getattr(
                             fig.layout.title, "text", None
                         ):
@@ -911,6 +906,15 @@ For questions or support, contact: IVI Water Trends Team"""
                             clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
                             if clean_text:
                                 title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+                                doc_title = html_lib.escape(clean_text, quote=True)
+
+                        # Add title and viewport for accessibility and mobile responsiveness
+                        html_content = html_content.replace(
+                            "<head>",
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{doc_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                        )
+
+                        # Add accessibility attributes to the graph container with dynamic ARIA label
 
                         html_content = html_content.replace(
                             'class="plotly-graph-div"',

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -776,14 +776,9 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
+            # Extract title for accessibility attributes and <title> tag
             title_text = "Interactive Water Trends Chart"
+            doc_title = "Water Trends Dashboard"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
@@ -796,6 +791,15 @@ class WaterTrendsVisualizer:
                     title_text = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
+                    doc_title = html_lib.escape(clean_text, quote=True)
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{doc_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
+            # Add accessibility attributes to the graph container with dynamic ARIA label
 
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
@@ -904,14 +908,9 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
+            # Extract title for accessibility attributes and <title> tag
             title_text = "Interactive Water Trends Chart"
+            doc_title = "Water Trends Visualization"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
@@ -924,6 +923,15 @@ class WaterTrendsVisualizer:
                     title_text = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
+                    doc_title = html_lib.escape(clean_text, quote=True)
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{doc_title}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
+            # Add accessibility attributes to the graph container with dynamic ARIA label
 
             html_content = html_content.replace(
                 'class="plotly-graph-div"',


### PR DESCRIPTION
**What:** Extracted specific chart titles from Plotly layout configurations and injected them dynamically into the `<title>` tags of HTML exports instead of using a hardcoded string.
**Why:** Hardcoding generic `<title>` tags in exported HTML dashboards creates a poor experience for screen reader users, as it prevents clear tab identification and navigation when multiple visualizations are opened (violating WCAG 2.4.2).
**Before/After:** Before, all HTML exports had the static title "Water Trends Dashboard" or "Water Trends Visualization". After, they have dynamic titles based on the specific chart, e.g., "Seasonal Water Trends - V001".
**Accessibility:** Improves WCAG 2.4.2 compliance and screen reader tab navigation.

---
*PR created automatically by Jules for task [15856434988159555180](https://jules.google.com/task/15856434988159555180) started by @dhruvhaldar*