### PR TITLE
🎨 Palette: [UX improvement] Dynamic HTML Document Titles for Screen Readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,6 @@
 ## 2024-11-20 - Chart Tooltip Readability
 **Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
 **Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.
+## 2024-05-18 - Dynamic HTML Document Titles for Screen Readers
+**Learning:** Exported interactive HTML charts previously used a static `<title>` tag (e.g., "Water Trends Dashboard" or "Visualization"). When multiple charts are open in different browser tabs, screen reader users and users with cognitive disabilities cannot distinguish between them, violating WCAG 2.4.2 (Page Titled).
+**Action:** Extract the specific chart title dynamically (e.g., from `fig.layout.title.text`) and inject it into the `<title>` tag during HTML export to ensure tabs are clearly identifiable.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -884,9 +884,25 @@ For questions or support, contact: IVI Water Trends Team"""
                     if format == "html":
                         filepath = self.output_dir / f"{base_filename}.html"
 
+                        # Extract title for document <title> and ARIA label
+                        title_text = "Interactive Water Trends Chart"
+                        if getattr(fig.layout, "title", None) and getattr(
+                            fig.layout.title, "text", None
+                        ):
+                            import re
+                            import html as html_lib
+
+                            # Extract text, remove HTML tags, and escape for attribute safety
+                            raw_text = html_lib.unescape(fig.layout.title.text)
+                            clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
+                            if clean_text:
+                                title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+
                         # Use to_html and inject CSP
                         # Optimization: Use CDN for plotly.js to reduce file size and improve speed
-                        html_content = fig.to_html(include_plotlyjs="cdn")
+                        html_content = fig.to_html(
+                            include_plotlyjs="cdn", config={"responsive": True}
+                        )
 
                         # Add lang="en" for accessibility
                         html_content = html_content.replace(
@@ -896,22 +912,10 @@ For questions or support, contact: IVI Water Trends Team"""
                         # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
                         )
 
                         # Add accessibility attributes to the graph container with dynamic ARIA label
-                        title_text = "Interactive Water Trends Chart"
-                        if getattr(fig.layout, "title", None) and getattr(
-                            fig.layout.title, "text", None
-                        ):
-                            import re, html as html_lib
-
-                            # Extract text, remove HTML tags, and escape for attribute safety
-                            raw_text = html_lib.unescape(fig.layout.title.text)
-                            clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
-                            if clean_text:
-                                title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
-
                         html_content = html_content.replace(
                             'class="plotly-graph-div"',
                             f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -769,25 +769,13 @@ class WaterTrendsVisualizer:
         )
 
         if save_path:
-            # Generate HTML content
-            # Optimization: Use CDN for plotly.js to reduce file size and improve speed
-            html_content = fig.to_html(include_plotlyjs="cdn")
-
-            # Add lang="en" for accessibility
-            html_content = html_content.replace("<html>", '<html lang="en">')
-
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
+            # Extract title for document <title> and ARIA label
             title_text = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
-                import re, html as html_lib
+                import re
+                import html as html_lib
 
                 # Extract text, remove HTML tags, and escape for attribute safety
                 raw_text = html_lib.unescape(fig.layout.title.text)
@@ -797,6 +785,22 @@ class WaterTrendsVisualizer:
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
 
+            # Generate HTML content
+            # Optimization: Use CDN for plotly.js to reduce file size and improve speed
+            html_content = fig.to_html(
+                include_plotlyjs="cdn", config={"responsive": True}
+            )
+
+            # Add lang="en" for accessibility
+            html_content = html_content.replace("<html>", '<html lang="en">')
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
+            # Add accessibility attributes to the graph container with dynamic ARIA label
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
                 f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',
@@ -896,26 +900,13 @@ class WaterTrendsVisualizer:
         filepath = os.path.join(save_dir, f"{filename}.{format}")
 
         if format == "html":
-            # Generate HTML string
-            # Optimization: Use CDN for plotly.js to reduce file size and improve speed
-            kwargs.setdefault("include_plotlyjs", "cdn")
-            html_content = fig.to_html(**kwargs)
-
-            # Add lang="en" for accessibility
-            html_content = html_content.replace("<html>", '<html lang="en">')
-
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
-            # Add accessibility attributes to the graph container with dynamic ARIA label
+            # Extract title for document <title> and ARIA label
             title_text = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
                 fig.layout.title, "text", None
             ):
-                import re, html as html_lib
+                import re
+                import html as html_lib
 
                 # Extract text, remove HTML tags, and escape for attribute safety
                 raw_text = html_lib.unescape(fig.layout.title.text)
@@ -925,6 +916,24 @@ class WaterTrendsVisualizer:
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
 
+            # Generate HTML string
+            # Optimization: Use CDN for plotly.js to reduce file size and improve speed
+            kwargs.setdefault("include_plotlyjs", "cdn")
+            if "config" not in kwargs:
+                kwargs["config"] = {}
+            kwargs["config"]["responsive"] = True
+            html_content = fig.to_html(**kwargs)
+
+            # Add lang="en" for accessibility
+            html_content = html_content.replace("<html>", '<html lang="en">')
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
+
+            # Add accessibility attributes to the graph container with dynamic ARIA label
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
                 f'class="plotly-graph-div" role="region" aria-label="{title_text}" tabindex="0"',


### PR DESCRIPTION
💡 **What**: Extracted the chart title from the Plotly figure and dynamically injected it into the `<title>` tag when exporting interactive HTML charts. Added `config={"responsive": True}`.
🎯 **Why**: When users export multiple interactive charts and open them in separate tabs, a static generic title (e.g., "Water Trends Dashboard") makes it impossible for screen reader users and users with cognitive disabilities to distinguish between the tabs. Making it responsive also enhances the mobile UX. 
📸 **Before/After**: Visually, the browser tab title now reflects the specific chart content rather than a generic name. Charts also resize properly on small screens.
♿ **Accessibility**: Directly fixes a violation of WCAG 2.4.2 (Page Titled). Now tabs announce their specific contents reliably to assistive technologies.

---
*PR created automatically by Jules for task [317524532722367866](https://jules.google.com/task/317524532722367866) started by @dhruvhaldar*