### PR TITLE
🎨 Palette: [UX improvement] Add dynamic document `<title>` for Plotly HTML exports

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -43,3 +43,6 @@
 ## 2024-11-20 - Chart Tooltip Readability
 **Learning:** Default tooltips in Plotly display raw floating-point numbers or large integers without thousands separators, making it difficult for users to read and quickly parse values in interactive dashboards, creating inconsistency with formatted static reports.
 **Action:** When customizing Plotly chart tooltips (`hovertemplate`), always use d3-style formatting syntax (e.g., `%{y:,.2f}` or `%{y:,}`) to include thousands separators and maintain visual consistency and readability for large numerical values.
+## 2024-05-18 - Document Titles for Screen Readers
+**Learning:** Hardcoding generic `<title>` tags like `Water Trends Dashboard` across all visualizations creates a confusing experience for screen reader users navigating between browser tabs, as tabs cannot be distinguished without reading their content.
+**Action:** Always extract the specific, dynamic chart title (e.g., from `fig.layout.title.text`) and inject it into the `<title>` tag when generating standalone HTML or reports with Plotly. This ensures clear tab identification for screen readers (WCAG 2.4.2).

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -893,12 +893,6 @@ For questions or support, contact: IVI Water Trends Team"""
                             "<html>", '<html lang="en">'
                         )
 
-                        # Add title and viewport for accessibility and mobile responsiveness
-                        html_content = html_content.replace(
-                            "<head>",
-                            '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-                        )
-
                         # Add accessibility attributes to the graph container with dynamic ARIA label
                         title_text = "Interactive Water Trends Chart"
                         if getattr(fig.layout, "title", None) and getattr(
@@ -911,6 +905,12 @@ For questions or support, contact: IVI Water Trends Team"""
                             clean_text = re.sub(r"<[^>]+>", "", raw_text).strip()
                             if clean_text:
                                 title_text = f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
+
+                        # Add title and viewport for accessibility and mobile responsiveness
+                        html_content = html_content.replace(
+                            "<head>",
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                        )
 
                         html_content = html_content.replace(
                             'class="plotly-graph-div"',

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -776,12 +776,6 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Dashboard</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
             # Add accessibility attributes to the graph container with dynamic ARIA label
             title_text = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
@@ -796,6 +790,12 @@ class WaterTrendsVisualizer:
                     title_text = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
 
             html_content = html_content.replace(
                 'class="plotly-graph-div"',
@@ -904,12 +904,6 @@ class WaterTrendsVisualizer:
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
 
-            # Add title and viewport for accessibility and mobile responsiveness
-            html_content = html_content.replace(
-                "<head>",
-                '<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>Water Trends Visualization</title>\n    <style>.plotly-graph-div:focus-visible { outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }</style>',
-            )
-
             # Add accessibility attributes to the graph container with dynamic ARIA label
             title_text = "Interactive Water Trends Chart"
             if getattr(fig.layout, "title", None) and getattr(
@@ -924,6 +918,12 @@ class WaterTrendsVisualizer:
                     title_text = (
                         f"{html_lib.escape(clean_text, quote=True)} - Interactive Chart"
                     )
+
+            # Add title and viewport for accessibility and mobile responsiveness
+            html_content = html_content.replace(
+                "<head>",
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+            )
 
             html_content = html_content.replace(
                 'class="plotly-graph-div"',


### PR DESCRIPTION
💡 What: Updated `ivi_water/visualizer.py` and `ivi_water/export_utils.py` to extract specific chart titles (via `fig.layout.title.text`) and inject them into the `<title>` tag of Plotly HTML exports, replacing static titles.
🎯 Why: Generic document `<title>` tags like "Water Trends Dashboard" cause all visualizations to have identical tab names, making it confusing for users—especially screen reader users—to navigate between tabs.
📸 Before/After: Before, all tabs would generically say "Water Trends Visualization" or "Water Trends Dashboard". Now, they describe the chart (e.g., "Water Trends - Location A").
♿ Accessibility: WCAG 2.4.2 mandates that web pages have titles that describe topic or purpose. Dynamically generated titles provide this necessary context for non-visual and visual users alike.

---
*PR created automatically by Jules for task [1063222729241323263](https://jules.google.com/task/1063222729241323263) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Exported HTML reports and visualizations now generate document titles dynamically from chart data instead of generic defaults, making exported files more distinguishable in browser tabs.

* **Documentation**
  * Updated palette guidelines for dynamic title generation standards in HTML exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->