### PR TITLE
🎨 Palette: [UX improvement] Make Plotly HTML exports responsive

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -46,3 +46,6 @@
 ## 2024-05-18 - Document Titles for Screen Readers
 **Learning:** Hardcoding generic `<title>` tags like `Water Trends Dashboard` across all visualizations creates a confusing experience for screen reader users navigating between browser tabs, as tabs cannot be distinguished without reading their content.
 **Action:** Always extract the specific, dynamic chart title (e.g., from `fig.layout.title.text`) and inject it into the `<title>` tag when generating standalone HTML or reports with Plotly. This ensures clear tab identification for screen readers (WCAG 2.4.2).
+## 2024-05-18 - Plotly HTML Export Responsiveness
+**Learning:** Default Plotly interactive charts exported to HTML (`fig.to_html()`) do not automatically resize when the browser window or viewport changes, particularly on mobile screens. If a fixed width or height is set in the chart layout, this leads to layout breaks or forces the user to scroll horizontally.
+**Action:** When exporting Plotly charts to HTML via `to_html()`, always pass `config={'responsive': True}`. This explicitly enables responsiveness and ensures the chart container adapts fluidly to the screen size.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -886,7 +886,7 @@ For questions or support, contact: IVI Water Trends Team"""
 
                         # Use to_html and inject CSP
                         # Optimization: Use CDN for plotly.js to reduce file size and improve speed
-                        html_content = fig.to_html(include_plotlyjs="cdn")
+                        html_content = fig.to_html(include_plotlyjs="cdn", config={'responsive': True})
 
                         # Add lang="en" for accessibility
                         html_content = html_content.replace(

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -787,7 +787,7 @@ class WaterTrendsVisualizer:
         if save_path:
             # Generate HTML content
             # Optimization: Use CDN for plotly.js to reduce file size and improve speed
-            html_content = fig.to_html(include_plotlyjs="cdn")
+            html_content = fig.to_html(include_plotlyjs="cdn", config={'responsive': True})
 
             # Add lang="en" for accessibility
             html_content = html_content.replace("<html>", '<html lang="en">')
@@ -915,6 +915,7 @@ class WaterTrendsVisualizer:
             # Generate HTML string
             # Optimization: Use CDN for plotly.js to reduce file size and improve speed
             kwargs.setdefault("include_plotlyjs", "cdn")
+            kwargs["config"] = {**kwargs.get("config", {}), "responsive": True}
             html_content = fig.to_html(**kwargs)
 
             # Add lang="en" for accessibility


### PR DESCRIPTION
💡 **What:** Added `config={'responsive': True}` to all instances where Plotly charts are exported to HTML (`fig.to_html()`).

🎯 **Why:** Default Plotly HTML exports lack automatic resizing when the browser viewport changes, particularly on smaller/mobile screens. If fixed sizes are set, this leads to a broken layout or forces awkward horizontal scrolling. Enabling responsiveness fixes this layout jank seamlessly.

📸 **Before/After:**
*Before:* HTML exports had fixed container boundaries and would overflow or break layouts on narrow mobile screens.
*After:* Interactive charts resize dynamically and adapt cleanly to their container / viewport width.

♿ **Accessibility:** Prevents elements from overlapping or clipping on small viewports, ensuring content remains readable and accessible for users utilizing zoomed-in views or mobile devices (WCAG 1.4.10 Reflow).

---
*PR created automatically by Jules for task [9873141189230275886](https://jules.google.com/task/9873141189230275886) started by @dhruvhaldar*