### PR TITLE
🎨 Palette: [UX improvement] Add caption to HTML tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,6 @@
 ## 2024-11-20 - HTML Table Data A11y and UX Typography
 **Learning:** Pandas `to_html` tables lack proper screen reader associations (`scope="col"`) on header elements, causing cognitive overhead. Additionally, numerical value columns default to left-alignment and proportional fonts, making large numbers difficult to scan and compare across rows.
 **Action:** Injected `scope="col"` into generated `<th>` tags for accessibility, and added CSS to right-align the value column (`td:last-child`, `th:last-child`) along with `font-variant-numeric: tabular-nums` to ensure numerical digits align cleanly for UX scanning.
+## 2026-04-28 - HTML Table Captions
+**Learning:** Pandas `to_html` generates tables without a semantic `<caption>` tag, which deprives screen reader users of immediate context about the table's purpose before they start navigating its content.
+**Action:** Always inject a `<caption>` tag (e.g., `<caption>Summary Statistics</caption>`) into generated HTML tables immediately after the opening `<table>` tag to ensure WCAG compliance and improve accessibility.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -561,6 +561,7 @@ class ExportUtils:
 
         table_html = summary_df.to_html(index=False, classes='summary-table')
         table_html = table_html.replace("<th>", '<th scope="col">')
+        table_html = table_html.replace('<table border="1" class="dataframe summary-table">', '<table border="1" class="dataframe summary-table">\n  <caption>Summary Statistics</caption>')
 
         # HTML content
         html_content = f"""


### PR DESCRIPTION
💡 What: Injected a `<caption>Summary Statistics</caption>` element into the Pandas-generated HTML table.
🎯 Why: Pandas `to_html` generates tables without a semantic `<caption>` tag. This deprives screen reader users of immediate context about the table's purpose before they start navigating its content.
📸 Before/After: Visual presentation remains identical, but the DOM now includes a `<caption>` for A11y.
♿ Accessibility: Ensures WCAG compliance by giving screen readers context regarding the data presented in the table.

---
*PR created automatically by Jules for task [7439681089710993044](https://jules.google.com/task/7439681089710993044) started by @dhruvhaldar*