### PR TITLE
🎨 Palette: [UX improvement] Add semantic caption to HTML tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,6 @@
 ## 2024-11-20 - HTML Table Data A11y and UX Typography
 **Learning:** Pandas `to_html` tables lack proper screen reader associations (`scope="col"`) on header elements, causing cognitive overhead. Additionally, numerical value columns default to left-alignment and proportional fonts, making large numbers difficult to scan and compare across rows.
 **Action:** Injected `scope="col"` into generated `<th>` tags for accessibility, and added CSS to right-align the value column (`td:last-child`, `th:last-child`) along with `font-variant-numeric: tabular-nums` to ensure numerical digits align cleanly for UX scanning.
+## 2024-10-18 - HTML Table Semantic Captions
+**Learning:** When generating HTML tables from Pandas DataFrames (e.g., via `to_html`), missing a semantic `<caption>` tag deprives screen reader users of essential context before they navigate the table data.
+**Action:** Always inject a semantic `<caption>` tag into the table output to provide essential context.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -561,6 +561,7 @@ class ExportUtils:
 
         table_html = summary_df.to_html(index=False, classes='summary-table')
         table_html = table_html.replace("<th>", '<th scope="col">')
+        table_html = table_html.replace("<thead>", "<caption>Summary Statistics Data</caption>\n  <thead>")
 
         # HTML content
         html_content = f"""


### PR DESCRIPTION
**💡 What:** Added a semantic `<caption>` tag to Pandas-generated HTML tables in the application.

**🎯 Why:** Missing semantic captions on HTML tables deprive screen reader users of essential context before they navigate into the table data. This small addition makes the generated reports significantly more accessible and navigable for users relying on assistive technologies.

**📸 Before/After:**
- *Before:* `<table border="1" class="dataframe summary-table"> <thead>...`
- *After:* `<table border="1" class="dataframe summary-table"> <caption>Summary Statistics Data</caption> <thead>...`

**♿ Accessibility:** Improves adherence to Web Content Accessibility Guidelines (WCAG) by providing a programmatically determinable descriptive caption for data tables, enhancing the experience for screen reader users navigating the summary statistics. Also journaled the learning for future reference.

---
*PR created automatically by Jules for task [13055089964823704875](https://jules.google.com/task/13055089964823704875) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Tables in HTML reports now include captions for improved readability.

* **Documentation**
  * Updated table formatting guidelines for HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->