### PR TITLE
🎨 Palette: Add Back to Top link in HTML reports

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -71,3 +71,7 @@
 ## 2024-05-09 - PDF Report Table Contrast Ratio
 **Learning:** The default `colors.grey` background with `colors.whitesmoke` text in ReportLab tables produces a contrast ratio of ~2.5:1, which fails WCAG AA standards (4.5:1 required) and makes the PDF headers hard to read.
 **Action:** Replaced `colors.grey` with a brand-aligned `colors.HexColor('#226699')` to achieve a 7.8:1 contrast ratio, passing WCAG AAA and improving readability for all users.
+
+## 2024-05-24 - Smooth Scrolling & Back-to-Top in HTML Reports
+**Learning:** Generated HTML reports with large data tables can trap keyboard users at the bottom of the document. Standard anchor links without smooth scrolling can be disorienting.
+**Action:** Always include a "Back to Top" link with `scroll-behavior: smooth` in generated long-form HTML documents to ensure keyboard users can easily return to the main navigation/header, and use `@media print` to hide it.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -612,7 +612,11 @@ class ExportUtils:
                 .print-button:hover {{ background-color: #1a4f76; }}
                 .print-button:active {{ transform: scale(0.98); }}
                 .print-button:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
-                @media print {{ .print-button, .skip-link {{ display: none !important; }} }}
+                html {{ scroll-behavior: smooth; }}
+                .back-to-top {{ display: inline-block; margin-top: 20px; padding: 8px 16px; color: #226699; text-decoration: none; font-weight: 500; border-radius: 4px; transition: background-color 0.2s ease; }}
+                .back-to-top:hover {{ background-color: #f1f1f1; }}
+                .back-to-top:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; }}
+                @media print {{ .print-button, .skip-link, .back-to-top {{ display: none !important; }} }}
             </style>
         </head>
         <body>
@@ -641,6 +645,10 @@ class ExportUtils:
                         {''.join(f'<li class="badge">{col}</li>' for col in safe_columns)}
                     </ul>
                 </section>
+
+                <footer style="text-align: center; border-top: 1px solid #ddd; margin-top: 40px; padding-top: 20px; padding-bottom: 20px;">
+                    <a href="#summary-stats-title" class="back-to-top" aria-label="Scroll back to top of the report">↑ Back to Top</a>
+                </footer>
             </main>
         </body>
         </html>


### PR DESCRIPTION
## 💡 What
Added a "Back to Top" footer link to generated HTML reports with `scroll-behavior: smooth` applied to the document. 

## 🎯 Why
In long-form generated reports containing massive data tables, users (especially keyboard users) can become trapped at the bottom of the page. This subtle UX improvement allows users to smoothly return to the top and navigate other sections seamlessly. 

## 📸 Before/After
* **Before**: Users reaching the end of the data overview had no quick way to navigate back to the report header without manually scrolling all the way up. Keyboard users had to tab backwards aggressively.
* **After**: A smooth "Back to Top" link is available at the bottom of the content, which politely hides itself when the document is printed.

## ♿ Accessibility
* Enabled `scroll-behavior: smooth` to ensure screen reading transitions and visual jumps are gentle rather than jarring.
* Provided clear `:focus-visible` styling (`#ff7f0e`) for the "Back to Top" link.
* Added `aria-label` to provide explicit guidance to assistive technologies.

---
*PR created automatically by Jules for task [15752909629768474769](https://jules.google.com/task/15752909629768474769) started by @dhruvhaldar*