### PR TITLE
🎨 Palette: Add thousands separator to CLI output

### DIFF
--- a/ivi_water/cli.py
+++ b/ivi_water/cli.py
@@ -263,7 +263,7 @@ def get_spatial_units(
 
             file_size = output_path.stat().st_size
             logger.info(
-                f"Saved {len(df)} spatial units to {output_path} ({file_size} bytes)"
+                f"Saved {len(df):,} spatial units to {output_path} ({file_size:,} bytes)"
             )
 
         except Exception as e:
@@ -294,7 +294,7 @@ def get_spatial_units(
 
         # Log completion
         logger.info(
-            f"Successfully completed spatial units fetch: {len(df)} units retrieved"
+            f"Successfully completed spatial units fetch: {len(df):,} units retrieved"
         )
 
     except click.ClickException:
@@ -418,7 +418,7 @@ def fetch_water_data(
         # Display progress
         click.echo(
             click.style(
-                f"Fetching water data for {len(location_list)} locations...", fg="blue"
+                f"Fetching water data for {len(location_list):,} locations...", fg="blue"
             )
         )
 
@@ -457,7 +457,7 @@ def fetch_water_data(
 
             file_size = output_path.stat().st_size
             logger.info(
-                f"Saved {len(water_df)} water records to {output_path} ({file_size} bytes)"
+                f"Saved {len(water_df):,} water records to {output_path} ({file_size:,} bytes)"
             )
 
         except Exception as e:
@@ -495,8 +495,8 @@ def fetch_water_data(
 
         # Log completion
         logger.info(
-            f"Successfully completed water data fetch: {len(water_df)} records "
-            f"for {len(location_list)} locations from {start_year}-{end_year}"
+            f"Successfully completed water data fetch: {len(water_df):,} records "
+            f"for {len(location_list):,} locations from {start_year}-{end_year}"
         )
 
     except click.ClickException:


### PR DESCRIPTION
**What**: Added thousands separators (`,`) to numerical values like record counts, unit counts, and file sizes in terminal log outputs and echo statements within `ivi_water/cli.py`.

**Why**: Unformatted large numbers (e.g. 150000) displayed in CLI outputs are difficult to read and process at a glance compared to properly formatted numbers (150,000). Applying thousands separators reduces cognitive load and improves readability. CLI output is an interface that benefits from basic typography and UX best practices too.

**Before/After**:
Before: `Saved 150000 water records to ./outputs (3501239 bytes)`
After: `Saved 150,000 water records to ./outputs (3,501,239 bytes)`

**Accessibility**: N/A - Primary focus is on scannability and UX rather than structural a11y, though clearer numerical groupings broadly assist users.

---
*PR created automatically by Jules for task [18145072334587313855](https://jules.google.com/task/18145072334587313855) started by @dhruvhaldar*