### PR TITLE
🎨 Palette: [UX improvement] Improve Screen Reader Accessibility for HTML Summary Tables

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -75,3 +75,7 @@
 ## 2024-05-24 - Smooth Scrolling & Back-to-Top in HTML Reports
 **Learning:** Generated HTML reports with large data tables can trap keyboard users at the bottom of the document. Standard anchor links without smooth scrolling can be disorienting.
 **Action:** Always include a "Back to Top" link with `scroll-behavior: smooth` in generated long-form HTML documents to ensure keyboard users can easily return to the main navigation/header, and use `@media print` to hide it.
+
+## 2024-05-11 - Table Row Headers Accessibility
+**Learning:** By default, Pandas `to_html()` generates data rows with `<td>` tags for the first column. This makes it difficult for screen readers to properly associate row data with their corresponding row headers, creating cognitive overhead for users relying on assistive technologies.
+**Action:** Always ensure that row headers in HTML tables (the first column indicating what the row represents) use `<th scope="row">` instead of `<td>` to properly define their semantic role and improve accessibility for screen readers.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -9,6 +9,7 @@ and create PDF-friendly summaries.
 import os
 import logging
 import html
+import re
 from typing import List, Optional
 from datetime import datetime
 from pathlib import Path
@@ -568,6 +569,8 @@ class ExportUtils:
         table_html = table_html.replace(
             "<thead>", "<caption>Summary Statistics Data</caption>\n  <thead>"
         )
+        # Apply scope="row" to the first column <td>s for screen reader accessibility
+        table_html = re.sub(r'(<tr>\s*)<td>(.*?)</td>', r'\1<th scope="row">\2</th>', table_html)
 
         # HTML content
         html_content = f"""


### PR DESCRIPTION
💡 **What**: Updated `ivi_water/export_utils.py` to ensure that when generating the HTML summary table, the first column uses `<th scope="row">` instead of `<td>` tags.
🎯 **Why**: Pandas `to_html()` defaults to outputting all row data as `<td>` tags. For tables with clear row headers (like the summary metrics), this lack of semantic structure makes it difficult for screen readers to associate data values with their row descriptions, creating a poor experience.
📸 **Before/After**: Before, row headers were `<td>Total Records</td>`. After, they are `<th scope="row">Total Records</th>`.
♿ **Accessibility**: Enhances table readability for non-visual users navigating with screen readers by properly associating the data cells with the correct row header.

---
*PR created automatically by Jules for task [12549967887399956468](https://jules.google.com/task/12549967887399956468) started by @dhruvhaldar*