### PR TITLE
🎨 Palette: Fix dark mode accessibility for HTML report backgrounds

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -95,3 +95,6 @@
 ## 2024-05-24 - Aria-Hidden for Decorative Text Symbols
 **Learning:** Using text characters as decorative icons (like "↑" for a back-to-top link) causes screen readers to announce them literally (e.g., "Upwards arrow Back to Top"), creating a confusing and noisy experience for visually impaired users.
 **Action:** Always wrap decorative text symbols in `<span aria-hidden="true">` to ensure they are ignored by screen readers while remaining visible to sighted users.
+## 2024-05-19 - Dark Mode Accessibility Fix in HTML Reports
+**Learning:** Hardcoded white backgrounds (`background-color: #fff;`) with unstyled `color` properties on child elements (or default light text) can lead to invisible text for users with OS/browser-level Dark Mode enabled.
+**Action:** When setting specific background colors (like white or light gray) on elements like `.summary` or the `body` tag, always explicitly define the text `color` to ensure sufficient contrast regardless of the user's system preferences.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -589,8 +589,8 @@ class ExportUtils:
                 h2 {{ color: #34495e; border-bottom: 2px solid #226699; }}
                 table {{ border-collapse: collapse; width: 100%; margin: 20px 0; }}
                 th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
-                th {{ background-color: #f2f2f2; font-weight: bold; }}
-                .summary {{ background-color: #f8f9fa; padding: 15px; border-radius: 5px; }}
+                th {{ background-color: #f2f2f2; color: #333; font-weight: bold; }}
+                .summary {{ background-color: #f8f9fa; color: #333; padding: 15px; border-radius: 5px; }}
                 .skip-link {{
                     position: absolute;
                     top: -40px;


### PR DESCRIPTION
💡 What: Added explicit `color: #333;` to `th` and `.summary` CSS classes in the HTML report template (`ivi_water/export_utils.py`). Also appended a learning entry to `.Jules/palette.md`.
🎯 Why: Resolves a critical dark mode accessibility issue where hardcoded light backgrounds (`#f2f2f2` and `#f8f9fa`) without explicit text colors caused text to become invisible if the user's OS or browser forced a light default text color.
♿ Accessibility: Ensures WCAG contrast compliance for users who have system-level Dark Mode enabled, making the summary text and table headers readable.

---
*PR created automatically by Jules for task [5545982735073493336](https://jules.google.com/task/5545982735073493336) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text visibility in HTML reports when using operating system or browser dark mode by ensuring proper color contrast.

* **Documentation**
  * Added accessibility guideline for dark mode considerations in report generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dhruvhaldar/IVI-Water-Trends---Interactive-Visualization-and-Impact-Assessment-Tool/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->