### PR TITLE
🎨 Palette: [UX improvement] Add explicit tabular headers and text dimming to CLI sample data output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -105,3 +105,7 @@
 ## 2024-05-21 - CLI Success Feedback Enhancements
 **Learning:** Text-only or plainly formatted CLI feedback (e.g., using a plain "✓") can easily get lost in dense terminal output, making it harder for users to quickly scan for successful task completions. Consistent color and highly visible emojis dramatically improve the CLI's scannability.
 **Action:** Consistently use the `✅` emoji and explicit `click.style(..., fg="green")` to style success messages in CLI tools to ensure they stand out clearly against standard terminal text.
+
+## 2024-11-20 - CLI Tabular Data Formatting and Scannability
+**Learning:** Printing tabular data to the CLI without column headers forces users to guess what each value represents, causing cognitive friction. Additionally, secondary text (like "... and 40 more records") can distract from the main data if not visually de-emphasized.
+**Action:** Always include explicit tabular headers styled distinctly (e.g., cyan color) when printing table rows in the CLI, and use `click.style(..., dim=True)` to de-emphasize secondary or trailing text to keep user focus on the primary data.

--- a/ivi_water/cli.py
+++ b/ivi_water/cli.py
@@ -227,7 +227,7 @@ def get_spatial_units(
             raise click.ClickException(f"Failed to fetch spatial units: {e}")
 
         if not units:
-            click.echo(click.style("No spatial units found.", fg="yellow"))
+            click.echo(click.style("⚠️ No spatial units found. Try a different unit type or state.", fg="yellow"))
             logger.warning(
                 f"No spatial units found for unit_type='{unit_type}', state='{state}'"
             )
@@ -239,7 +239,7 @@ def get_spatial_units(
 
             if df.empty:
                 click.echo(
-                    click.style("No valid spatial unit data found.", fg="yellow")
+                    click.style("⚠️ No valid spatial unit data found. Try a different unit type or state.", fg="yellow")
                 )
                 return
 
@@ -278,6 +278,10 @@ def get_spatial_units(
         if len(df) > 0:
             click.echo("\n" + click.style("Sample data:", fg="blue", bold=True))
 
+            # Add explicit tabular headers
+            click.echo(click.style(f"  {'ID':<15} | {'Name':<30} | State", fg="cyan"))
+            click.echo(click.style(f"  {'-'*15}-+-{'-'*30}-+-{'-'*15}", fg="cyan", dim=True))
+
             # Display first few rows with formatting
             sample_size = min(5, len(df))
             sample_df = df.head(sample_size)
@@ -290,7 +294,7 @@ def get_spatial_units(
                 click.echo(f"  {safe_id:<15} | {safe_name:<30} | {safe_state}")
 
             if len(df) > sample_size:
-                click.echo(f"  ... and {len(df) - sample_size:,} more entries")
+                click.echo(click.style(f"  ... and {len(df) - sample_size:,} more entries", dim=True))
 
         # Log completion
         logger.info(
@@ -442,7 +446,7 @@ def fetch_water_data(
         if water_df.empty:
             click.echo(
                 click.style(
-                    "No water data found for the specified parameters.", fg="yellow"
+                    "⚠️ No water data found for the specified parameters. Try adjusting the year range or seasons.", fg="yellow"
                 )
             )
             logger.warning("No water data retrieved")
@@ -480,6 +484,11 @@ def fetch_water_data(
         # Show sample data
         if len(water_df) > 0:
             click.echo("\n" + click.style("Sample records:", fg="blue"))
+
+            # Add explicit tabular headers
+            click.echo(click.style(f"  {'Location':<8} | {'Year':<6} | {'Season':<10} | {'Water Area':<11} | Bodies", fg="cyan"))
+            click.echo(click.style(f"  {'-'*8}-+-{'-'*6}-+-{'-'*10}-+-{'-'*11}-+-{'-'*8}", fg="cyan", dim=True))
+
             sample_size = min(3, len(water_df))
             sample_df = water_df.head(sample_size)
 
@@ -492,7 +501,7 @@ def fetch_water_data(
                 )
 
             if len(water_df) > sample_size:
-                click.echo(f"  ... and {len(water_df) - sample_size:,} more records")
+                click.echo(click.style(f"  ... and {len(water_df) - sample_size:,} more records", dim=True))
 
         # Log completion
         logger.info(


### PR DESCRIPTION
💡 **What**: Added explicit, cyan-styled tabular headers for sample data output in `get_spatial_units` and `fetch_water_data` CLI commands. Dimmed secondary information (e.g., "... and X more records"). Improved empty state warning messages with emojis and actionable advice.

🎯 **Why**: Printing tabular data without headers forces users to guess column meanings, causing cognitive friction. Highlighting headers and dimming secondary text greatly improves terminal scannability, guiding user focus to primary data. Adding actionable advice to empty states helps users recover faster.

📸 **Before/After**: N/A (CLI change)

♿ **Accessibility**: Improves cognitive accessibility and general UX for CLI users by clearly labeling data columns, reducing visual clutter, and providing clearer recovery paths on errors.

---
*PR created automatically by Jules for task [8585602792677982741](https://jules.google.com/task/8585602792677982741) started by @dhruvhaldar*