### PR TITLE
🎨 Palette: [UX improvement] Add theme-color meta tag to HTML reports

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -118,3 +118,7 @@
 ## 2024-06-02 - Keyboard Accessible Tooltips for Metadata
 **Learning:** Adding descriptive `title` tooltips to metadata elements (like dataset column badges) provides excellent contextual help, but is inaccessible to keyboard users by default. Standard non-interactive elements (like `<li>` or `<span>`) do not receive focus, preventing keyboard users from seeing the native browser tooltip.
 **Action:** When adding tooltips to non-interactive informative elements, always add `tabindex="0"` to allow keyboard focus, and apply a clear `:focus-visible` outline alongside `cursor: help` to indicate interactivity to all users.
+
+## 2024-06-03 - Mobile Browser Theme Color
+**Learning:** Static HTML reports viewed on mobile browsers default to generic system colors for the address bar and status bar, which breaks visual immersion and makes the report feel disconnected from the brand experience.
+**Action:** Always include `<meta name="theme-color" content="[brand-color]">` in the `<head>` of generated HTML reports and charts to ensure the mobile browser UI matches the primary brand color, providing a more cohesive, app-like visual experience.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -604,6 +604,7 @@ class ExportUtils:
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <meta name="theme-color" content="#226699">
             <title>Water Trends Summary Report</title>
             <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">
             <style>
@@ -994,7 +995,7 @@ For questions or support, contact: IVI Water Trends Team"""
                         # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
                         )
 
                         html_content = html_content.replace(

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -836,7 +836,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
             )
 
             html_content = html_content.replace(
@@ -965,7 +965,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
             )
 
             html_content = html_content.replace(


### PR DESCRIPTION
💡 **What:** Added `<meta name="theme-color" content="#226699">` to the `<head>` of all generated HTML reports (`_create_html_report`, `create_visualization_exports`, and `save_figure`). Also fixed a missing `<link rel="icon">` in the `create_visualization_exports` HTML generator.
🎯 **Why:** Static HTML reports viewed on mobile browsers default to generic system colors for the address bar, which breaks visual immersion and makes the report feel disconnected. By specifying the theme color, mobile browsers will tint the UI to match the brand color, creating a seamless, app-like experience. Missing favicons result in generic browser default icons on tabs, making it harder for users to identify the report.
📸 **Before/After:** No visible changes on desktop, but on mobile devices (e.g., iOS Safari, Android Chrome), the browser UI will now tint to `#226699` instead of white/gray.
♿ **Accessibility:** This is a purely visual UX enhancement and does not negatively affect a11y. It provides visual consistency and context for mobile users.

---
*PR created automatically by Jules for task [3773816861030502784](https://jules.google.com/task/3773816861030502784) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML reports and interactive visualizations now include brand color display in mobile browser address bars.

* **Documentation**
  * Updated accessibility/HTML template checklist with theme-color tag requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->