### PR TITLE
🎨 Palette: Add theme-color to standalone HTML exports for mobile polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -118,3 +118,7 @@
 ## 2024-06-02 - Keyboard Accessible Tooltips for Metadata
 **Learning:** Adding descriptive `title` tooltips to metadata elements (like dataset column badges) provides excellent contextual help, but is inaccessible to keyboard users by default. Standard non-interactive elements (like `<li>` or `<span>`) do not receive focus, preventing keyboard users from seeing the native browser tooltip.
 **Action:** When adding tooltips to non-interactive informative elements, always add `tabindex="0"` to allow keyboard focus, and apply a clear `:focus-visible` outline alongside `cursor: help` to indicate interactivity to all users.
+
+## 2026-05-25 - HTML Report Mobile Browser UI Cohesion
+**Learning:** By default, mobile browser UIs (like the address bar and status bar) use a default system color, which can look disconnected from a generated HTML report or chart that has a strong brand identity.
+**Action:** When generating static HTML reports or interactive charts meant for browser viewing, always inject a `<meta name="theme-color" content="[brand-color]">` tag (e.g., `#226699`) into the `<head>` to ensure the mobile browser UI matches the primary brand color, providing a seamless and polished experience.

--- a/ivi_water/export_utils.py
+++ b/ivi_water/export_utils.py
@@ -604,6 +604,7 @@ class ExportUtils:
         <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <meta name="theme-color" content="#226699">
             <title>Water Trends Summary Report</title>
             <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">
             <style>
@@ -994,7 +995,7 @@ For questions or support, contact: IVI Water Trends Team"""
                         # Add title and viewport for accessibility and mobile responsiveness
                         html_content = html_content.replace(
                             "<head>",
-                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                            f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
                         )
 
                         html_content = html_content.replace(

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -836,7 +836,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
             )
 
             html_content = html_content.replace(
@@ -965,7 +965,7 @@ class WaterTrendsVisualizer:
             # Add title and viewport for accessibility and mobile responsiveness
             html_content = html_content.replace(
                 "<head>",
-                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
+                f'<head>\n    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n    <meta name="theme-color" content="#226699">\n    <title>{title_text}</title>\n    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">\n    <style>.plotly-graph-div:focus-visible {{ outline: 3px solid #ff7f0e; outline-offset: 2px; border-radius: 4px; }}</style>',
             )
 
             html_content = html_content.replace(


### PR DESCRIPTION
💡 What: Added `<meta name="theme-color" content="#226699">` to the generated standalone HTML reports and interactive charts.
🎯 Why: By default, mobile browser UIs (like the address bar) render in a default system color. Injecting a theme-color meta tag ensures the browser UI matches the primary brand color of the application, creating a more seamless and cohesive experience when viewing standalone HTML exports on mobile devices.
📸 Before/After: Before, mobile browsers would show default white/gray toolbars. After, they tint to match the app's `#226699` brand blue.
♿ Accessibility: N/A - Primary focus is on UX polish and cohesion.

---
*PR created automatically by Jules for task [6813047985503136350](https://jules.google.com/task/6813047985503136350) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML reports and Plotly visualizations now include theme-color styling, enabling mobile browser UI elements to match the brand color scheme.

* **Documentation**
  * Added guidance on theme-color injection for generated reports and charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->