### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute multi-location dashboard traces

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -78,3 +78,7 @@
 ## 2025-05-19 - [Avoid Redundant DataFrame Copies for Read-Only Downstream Operations]
 **Learning:** Calling `.copy()` on Pandas DataFrames (e.g., `df.copy()` or `df_filtered = df[...].copy()`) when the resulting DataFrame is only used for read-only operations (like passing to Plotly for visualization) forces Pandas to unnecessarily allocate memory and duplicate data. This is particularly wasteful when performed unconditionally or on massive datasets.
 **Action:** When filtering Pandas DataFrames for read-only downstream operations (like visualization), avoid chaining redundant `.copy()` calls. Slicing or boolean masking inherently returns a view or copy that is sufficient for non-mutating downstream tasks, bypassing expensive and wasteful memory reallocation.
+
+## 2025-05-19 - [Pandas groupby performance inside loops]
+**Learning:** Performing `groupby` on slices of a DataFrame iteratively inside a loop (e.g., `df[df['col'] == val].groupby().mean()`) is highly inefficient and creates redundant overhead, especially when combined with column casting (`astype("category")`) inside the loop.
+**Action:** When calculating grouped statistics needed for multiple specific entities in a loop, pre-compute the full `.groupby()` once across all entities outside the loop (using `.reset_index()`), and then filter the small resulting aggregated DataFrame inside the loop (e.g., `agg_df[agg_df['col'] == val]`). This eliminates repeated deep copies and categorization overhead.

--- a/ivi_water/visualizer.py
+++ b/ivi_water/visualizer.py
@@ -714,23 +714,26 @@ class WaterTrendsVisualizer:
                     )
 
         # Plot 2: Water body count over time
+        # Optimization: Pre-compute grouping outside the loop to avoid redundant copies and casting
+        df_counts_proc = df_filtered[["year", "location_id", "water_body_count"]].copy()
+        for col in ["year", "location_id"]:
+            if not isinstance(df_counts_proc[col].dtype, pd.CategoricalDtype):
+                df_counts_proc[col] = df_counts_proc[col].astype("category")
+
+        yearly_counts = (
+            df_counts_proc.groupby(["year", "location_id"], observed=True)["water_body_count"]
+            .mean()
+            .reset_index()
+        )
+
         for location in location_ids[:3]:
             safe_location = self._sanitize_text(location)
-            loc_data = df_filtered[df_filtered["location_id"] == location].copy()
-            # Optimization: Convert grouping columns to category for faster groupby
-            if "year" in loc_data.columns and not isinstance(
-                loc_data["year"].dtype, pd.CategoricalDtype
-            ):
-                loc_data["year"] = loc_data["year"].astype("category")
-
-            avg_counts = loc_data.groupby("year", observed=True)[
-                "water_body_count"
-            ].mean()
+            loc_data = yearly_counts[yearly_counts["location_id"] == location]
 
             fig.add_trace(
                 go.Scatter(
-                    x=avg_counts.index,
-                    y=avg_counts.values,
+                    x=loc_data["year"],
+                    y=loc_data["water_body_count"],
                     mode="lines+markers",
                     name=f"{safe_location} - Bodies",
                     showlegend=False,


### PR DESCRIPTION
**What:**
Optimized the `create_multi_location_dashboard` function in `visualizer.py` by pulling the Pandas `groupby` and `mean()` aggregation for water body counts outside of the location iteration loop. 

**Why:**
Previously, the code would slice the DataFrame, create a deep copy, cast columns to `category` dtype, and perform a `groupby()` independently inside a loop for each location. For data with high cardinality, this is an expensive, redundant anti-pattern that creates substantial overhead. 

**Impact:**
Eliminates redundant deep copies, categorical casting, and grouped execution overhead, making dashboard rendering much faster and more memory efficient when looping over large location counts.

**Measurement:**
Run `pytest` to confirm tests pass, and observe overall faster multi-location visualization dashboard generations for huge datasets.

---
*PR created automatically by Jules for task [8778145129931203700](https://jules.google.com/task/8778145129931203700) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced water body count dashboard performance for multi-location visualizations through optimized data aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->