### PR TITLE
🎨 Palette: Add empty state handling for merge-data command

### DIFF
--- a/ivi_water/cli.py
+++ b/ivi_water/cli.py
@@ -581,6 +581,16 @@ def merge_data(ctx, water_data, nrm_data, output):
 
         # Load water data
         water_df = processor.load_csv_safe(water_data)
+
+        if water_df.empty:
+            click.echo(
+                click.style(
+                    "⚠️ No data found in the input file. Please ensure the CSV is populated before merging.",
+                    fg="yellow",
+                )
+            )
+            return
+
         water_df = processor._clean_water_data(water_df)
 
         # Load NRM data if provided


### PR DESCRIPTION
💡 What: Added empty state check and actionable warning for the `merge-data` command.
🎯 Why: If users accidentally passed an empty CSV to the `merge-data` command, it threw a silent or confusing error (`ValueError: DataFrame is empty`) rather than explaining the issue and giving them actionable advice.
📸 Before/After: Before, it would fail with a python stack trace / ClickException. Now it prints: "⚠️ No data found in the input file. Please ensure the CSV is populated before merging."
♿ Accessibility: Improves CLI readability and provides a significantly better user experience by guiding the user back to the happy path instead of terminating silently or confusingly.

---
*PR created automatically by Jules for task [1231615054014784917](https://jules.google.com/task/1231615054014784917) started by @dhruvhaldar*