### PR TITLE
🎨 Palette: Add loading states to long-running CLI tasks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -125,3 +125,6 @@
 ## 2026-05-30 - Empty States with Actionable Advice
 **Learning:** When executing CLI commands that expect data inputs (like generating reports or visualizations), users are easily confused if the process fails silently or errors out when the input CSV is empty.
 **Action:** Always include an empty state check (e.g., `if df.empty:`) and provide clear, actionable advice with a warning emoji (e.g., '⚠️ No data found in the input file. Please ensure the CSV is populated before visualizing.') to guide users appropriately.
+## 2026-06-10 - Add explicit loading states to long-running CLI tasks
+**Learning:** Users often assume a CLI tool has hung if there is no immediate visual feedback during network requests or expensive data generation operations.
+**Action:** Always include a visual loading indicator (e.g., `click.echo(click.style("⏳ Fetching...", fg="blue"))`) before long-running tasks to reassure users that the process is working.

--- a/ivi_water/cli.py
+++ b/ivi_water/cli.py
@@ -220,6 +220,12 @@ def get_spatial_units(
             raise click.ClickException(f"API client initialization failed: {e}")
 
         # Fetch spatial units
+        click.echo(
+            click.style(
+                f"⏳ Fetching {unit_type} spatial units...",
+                fg="blue",
+            )
+        )
         try:
             units = client.get_spatial_units(unit_type, state)
         except Exception as e:
@@ -663,6 +669,13 @@ def visualize(ctx, data, location_id, chart_type, output, format):
 
         viz = WaterTrendsVisualizer()
 
+        click.echo(
+            click.style(
+                f"⏳ Generating {chart_type} chart...",
+                fg="blue",
+            )
+        )
+
         # Generate filename if not provided
         if not output:
             location_suffix = f"_{location_id}" if location_id else ""
@@ -734,6 +747,13 @@ def dashboard(ctx, data, locations, output):
             location_list = location_counts.index.tolist()
             df_filtered = df[df["location_id"].isin(location_list)]
 
+        click.echo(
+            click.style(
+                "⏳ Generating comprehensive dashboard...",
+                fg="blue",
+            )
+        )
+
         fig = viz.create_multi_location_dashboard(df_filtered, location_list)
 
         # Save dashboard using secure save_figure method
@@ -790,6 +810,13 @@ def generate_report(ctx, data, report_type, output):
             output = sanitize_filename(output)
         except ValueError as e:
             raise click.ClickException(f"Invalid output filename: {e}")
+
+        click.echo(
+            click.style(
+                f"⏳ Generating {report_type} report...",
+                fg="blue",
+            )
+        )
 
         if report_type == "summary":
             output_path = export_utils.generate_summary_report(


### PR DESCRIPTION
💡 What: Added explicit visual loading feedback messages (e.g., `⏳ Fetching spatial units...`) before long-running commands like `get_spatial_units`, `visualize`, `dashboard`, and `generate_report`.
🎯 Why: Users often assume a CLI tool has hung if there is no immediate visual feedback during network requests or expensive data generation operations. This provides immediate reassurance that the process is working.
♿ Accessibility: Improves overall usability and confidence in the system without interfering with screen reader usage.

---
*PR created automatically by Jules for task [4927827914859610414](https://jules.google.com/task/4927827914859610414) started by @dhruvhaldar*